### PR TITLE
Edits to clean up tutorials in Psi4NumPy-Basics module.

### DIFF
--- a/Tutorials/01_Psi4NumPy-Basics/1a_molecule.ipynb
+++ b/Tutorials/01_Psi4NumPy-Basics/1a_molecule.ipynb
@@ -72,7 +72,9 @@
     }
    },
    "source": [
-    "Here, not only does the variable `he` refer to the helium molecule, but rather an instance of the `psi4.core.Molecule` class in <span style='font-variant: small-caps'> Psi4</span>; this will be discussed in more detail later.  For a more complicated system than an isolated atom, the coordinates can be given in Cartesian or Z-Matrix formats:"
+    "Here, not only does the variable `he` refer to the helium molecule, but also an instance of the [`psi4.core.Molecule`](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Molecule \"Go to API\")\n",
+    "class in <span style='font-variant: small-caps'> Psi4</span>; this will be discussed in more detail later.  For a more\n",
+    "complicated system than an isolated atom, the coordinates can be given in Cartesian or Z-Matrix formats:"
    ]
   },
   {
@@ -179,7 +181,9 @@
     }
    },
    "source": [
-    "For non-bonded fragments, the charge and multiplicity should be given explicitly for each fragment.  If not, the charge and multiplicity given for the first fragment is assumed to be the same for all fragments.  In addition to defining the coordinates outright, variables can be used within the geometry specification strings:"
+    "For non-bonded fragments, the charge and multiplicity should be given explicitly for each fragment.  If not, the \n",
+    "charge and multiplicity given (or inferred) for the first fragment is assumed to be the same for all fragments.  In \n",
+    "addition to defining the coordinates outright, variables can be used within the geometry specification strings:"
    ]
   },
   {
@@ -219,7 +223,50 @@
     }
    },
    "source": [
-    "If we wish to define these variables after the molecule is built, as opposed to within the geometry specification itself, there are several ways to do so; one of which will be illustrated in the Lennard-Jones potential example below.  Finally, one can obtain useful information from a molecule by invoking one of several [`psi4.core.Molecule`](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Molecule \"Go to Documentation\") class methods on the molecule of interest.  For example, if we were interested in verifying that our doublet water cation from above is, in fact, a doublet, we could invoke\n",
+    "If we wish to define these variables after the molecule is built, as opposed to within the geometry specification \n",
+    "itself, there are several ways to do so; one of which will be illustrated in the Lennard-Jones potential example \n",
+    "below. \n",
+    "\n",
+    "When a Psi4 molecule is first built using psi4.geometry it is in an unfished state, as a user may wish to \n",
+    "tweak the molecule. This can be solved by calling update_geometry. This will update the molecule and restores sanity \n",
+    "to chemistry. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "h2cch2 = psi4.geometry(\"\"\"\n",
+    "H\n",
+    "C 1 HC\n",
+    "H 2 HC 1 A1\n",
+    "C 2 CC 3 A1 1 D1\n",
+    "H 4 HC 2 A1 1 D1\n",
+    "H 4 HC 2 A1 1 D2\n",
+    "\n",
+    "HC = 1.08\n",
+    "CC = 1.4\n",
+    "A1 = 120.0\n",
+    "D1 = 180.0\n",
+    "D2 = 0.0\n",
+    "\"\"\")\n",
+    "\n",
+    "print(\"Ethene has %d atoms\" % h2cch2.natom())\n",
+    "\n",
+    "\n",
+    "h2cch2.update_geometry()\n",
+    "print(\"Ethene has %d atoms\" % h2cch2.natom())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, one can obtain useful information from a molecule by invoking one of several [`psi4.core.Molecule`](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Molecule \"Go to Documentation\") class methods on the molecule of interest.  For example, if we were interested in verifying that our doublet water cation from above is, in fact, a doublet, we could invoke\n",
     "~~~python\n",
     "doublet_h2o_cation.multiplicity()\n",
     "~~~\n",
@@ -406,65 +453,14 @@
     "plt.plot(fpoints, fit_energies) # Fit data\n",
     "plt.plot([0,10], [0,0], 'k-') # Make a line at 0"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true,
-    "run_control": {
-     "frozen": false,
-     "read_only": false
-    }
-   },
-   "source": [
-    "When a Psi4 molecule is first built using psi4.geometry it is in an unfished state, as a user may wish to tweak the molecule. This can be solved by calling update_geometry. This will update the molecule and restores sanity to chemistry."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "h2cch2 = psi4.geometry(\"\"\"\n",
-    "H\n",
-    "C 1 HC\n",
-    "H 2 HC 1 A1\n",
-    "C 2 CC 3 A1 1 D1\n",
-    "H 4 HC 2 A1 1 D1\n",
-    "H 4 HC 2 A1 1 D2\n",
-    "\n",
-    "HC = 1.08\n",
-    "CC = 1.4\n",
-    "A1 = 120.0\n",
-    "D1 = 180.0\n",
-    "D2 = 0.0\n",
-    "\"\"\")\n",
-    "\n",
-    "print(\"Ethene has %d atoms\" % h2cch2.natom())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "h2cch2.update_geometry()\n",
-    "print(\"Ethene has %d atoms\" % h2cch2.natom())"
-   ]
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [Root]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "Python [Root]"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {

--- a/Tutorials/01_Psi4NumPy-Basics/1b_psi4_numpy_datasharing.ipynb
+++ b/Tutorials/01_Psi4NumPy-Basics/1b_psi4_numpy_datasharing.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -30,24 +30,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Converting this to the Psi4 Matrix class and back is as simple as:"
+    "Converting this to a Psi4 Matrix, which is an instance of the [`psi4.core.Matrix`](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Matrix \n",
+    "\"Go to API\") class, and back again is as simple as:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Allclose new_array, array: True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "psi4_matrix = psi4.core.Matrix.from_array(array)\n",
     "new_array = np.array(psi4_matrix)\n",
@@ -62,32 +55,18 @@
    },
    "source": [
     "## Views\n",
-    "Because both of these objects have the same in-memory data layout the conversion is accomplished through the NumPy [array_interface](https://docs.scipy.org/doc/numpy/reference/arrays.interface.html). This also opens the opportunity to manipulate the Psi4 Matrix and Vector classes directly in memory, we can do this through the `.np` attribute:"
+    "Because both of these objects have the same in-memory data layout the conversion is accomplished through the NumPy \n",
+    "[array_interface](https://docs.scipy.org/doc/numpy/reference/arrays.interface.html). This also opens the opportunity \n",
+    "to manipulate the Psi4 Matrix and Vector classes directly in memory.  To do this, we employ the `.np` attribute:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Zero Psi4 Matrix:\n",
-      "[[ 0.  0.  0.]\n",
-      " [ 0.  0.  0.]\n",
-      " [ 0.  0.  0.]]\n",
-      "\n",
-      "Matrix updated to ones:\n",
-      "[[ 1.  1.  1.]\n",
-      " [ 1.  1.  1.]\n",
-      " [ 1.  1.  1.]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "matrix = psi4.core.Matrix(3, 3)\n",
     "print(\"Zero Psi4 Matrix:\")\n",
@@ -109,21 +88,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[ 0.  0.  0.]\n",
-      " [ 0.  0.  0.]\n",
-      " [ 0.  0.  0.]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(psi4.core.Matrix(3, 3).np)"
    ]
@@ -137,24 +106,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[ 0.  0.  0.]\n",
-      " [ 0.  0.  0.]\n",
-      " [ 0.  0.  0.]]\n",
-      "[[ 0.  0.  0.]\n",
-      " [ 0.  0.  0.]\n",
-      " [ 0.  0.  0.]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "mat = psi4.core.Matrix(3, 3)\n",
     "print(mat.np)\n",
@@ -172,21 +128,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[ 0.71373  0.06426  0.16284]\n",
-      " [ 0.71058  0.13898  0.65268]\n",
-      " [ 0.89404  0.02648  0.05117]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "mat = psi4.core.Matrix(3, 3)\n",
     "mat_view = np.asarray(mat)\n",
@@ -204,21 +150,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[ 0.71373  0.06426  0.16284]\n",
-      " [ 0.71058  0.13898  0.65268]\n",
-      " [ 0.89404  0.02648  0.05117]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "mat_view = np.zeros((3, 3))\n",
     "\n",
@@ -231,24 +167,17 @@
    "metadata": {},
    "source": [
     "## Vector class\n",
-    "Like the Psi4 Matrix class, the Vector class has similar accessors:"
+    "Like the Psi4 Matrix class, the [`psi4.core.Vector`](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Vector \"Go to API\")\n",
+    "class has similar accessors:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[ 0.34589  0.99137  0.46597  0.03614  0.15314]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "arr = np.random.rand(5)\n",
     "vec = psi4.core.Vector.from_array(arr)\n",
@@ -259,21 +188,33 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
   }
  },
  "nbformat": 4,

--- a/Tutorials/01_Psi4NumPy-Basics/1c_wavefunction.ipynb
+++ b/Tutorials/01_Psi4NumPy-Basics/1c_wavefunction.ipynb
@@ -59,7 +59,7 @@
     }
    },
    "source": [
-    "Now that we've set the basics, let's use what we learned in the last tutorial to define a water molecule, in Z-matrix\n",
+    "Now that we've set the basics, let's use what we learned in the Molecule tutorial to define a water molecule, in Z-matrix\n",
     "format, specifying that we want $C_1$ symmetry (instead of letting <span style='font-variant: small-caps'> Psi4\n",
     "</span> detect the real symmetry $C_{2v}$):"
    ]
@@ -135,8 +135,8 @@
     "`'aug-cc-pvdz'` as an argument, but then we would have to remember to change the argument if we ever changed the\n",
     "<span style='font-variant: small-caps'> Psi4 </span> option in the `psi4.set_options()` block above. Generally, when \n",
     "creating something like a wavefunction or a basis <span style='font-variant: small-caps'> Psi4</span>-side, the class \n",
-    "instances themselves are what is used to do so.  (Don't worry too much about creating basis sets yet, we'll get there \n",
-    "in the next tutorial!) \n",
+    "instances themselves are what is used to do so.  (Don't worry too much about creating basis sets yet, we'll cover\n",
+    "these in more detail later.) \n",
     "\n",
     "Now that we have built an instance of the `Wavefunction` class, we can access our wavefunction's information by \n",
     "calling any of the member functions of the `Wavefucntion` class on our object.  For instance, the number of spin-up\n",
@@ -222,27 +222,28 @@
    },
    "source": [
     "Now, we can access information you would expect a wavefunction to carry -- basically everything we couldn't before.\n",
-    "Below is summarized several quatities which will be used throughout the modules and tutorials to come.  Make sure to\n",
-    "try each of them out on our shiny, new Hartree-Fock wavefunction!\n",
+    "Below is summarized several quatities which will be used throughout the modules and tutorials to come.  Below is the list\n",
+    "of wavefunction attributes available after a Hartree-Fock computation; make sure to try them out on our `scf_wfn`!\n",
     "\n",
     "| Quantity | Function(s) | Description |\n",
     "|----------|-------------|-------------|\n",
-    "| Energy   | [wfn.energy()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.energy \"Go to Documentation\") | Returns current energy of the wavefunction. |\n",
     "| Orbital Coefficients, **C** | [wfn.Ca()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.Ca \"Go to Documentation\"), [wfn.Cb()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.Cb \"Go to Documentation\") | Returns orbital coefficient matrix for $\\alpha$ (Ca) or $\\beta$ (Cb) orbitals. (Identical for restricted orbitals) |\n",
     "| Electron Density, **D** | [wfn.Da()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.Da \"Go to Documentation\"), [wfn.Db()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.Db \"Go to Documentation\") | One particle density matrices for $\\alpha$ (Da) and $\\beta$ (Db) electrons. (Identical for restricted orbitals) |\n",
+    "| Fock Matrix, **F** | [wfn.Fa()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.Fa \"Go to Documentation\"), [wfn.Fa()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.Fb \"Go to Documentation\") | Returns the Fock matrix. For wavefunction with unrestricted orbitals, distinct Fock matrices $F^{\\alpha}$ and $F^{\\beta}$ for $\\alpha$ and $\\beta$ orbitals, respectively, are created.|\n",
     "| Basis Set | [wfn.basisset()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.basisset \"Go to Documentation\") | Returns basis set associated with the wavefunciton. |\n",
-    "| Orbital Energies, $\\boldsymbol{\\epsilon}$ | [wfn.epsilon_a()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.epsilon_a \"Go to Documentation\"), [wfn.epsilon_b()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.epsilon_b \"Go to Documentation\") | Returns $\\alpha$ (a) and $\\beta$ (b) orbital energies. (Identical for restricted orbitlas) |\n",
+    "| $\\alpha$ ($\\beta$) electrons | [wfn.nalpha()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.nalpha \"Go to Documentation\"), [wfn.nbeta()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.nbeta \"Go to Documentation\") | Returns number of $\\alpha$ ($\\beta$) electrons of the wavefunction. |\n",
+    "| Irreducible Representations | [wfn.nirrep()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.nirrep \"Go to Documentation\") | Returns number of irreducible representations (number of symmetry elements). Several objects can utilize molecular symmetry in the wavefunction. |\n",
+    "| Occupied Orbitals | [wfn.ndoccpi()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.ndoccpi \"Go to Documentation\") | Returns number of doubly occupied orbitals per irrep in the wavefunction. |\n",
     "| Psi Variables | [wfn.variables()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.variables \"Go to Documentation\") | Returns all Psi variables associated with the method which computed the wavefunction. |\n",
+    "| Energy   | [wfn.energy()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.energy \"Go to Documentation\") | Returns current energy of the wavefunction. |\n",
+    "| Orbital Energies, $\\boldsymbol{\\epsilon}$ | [wfn.epsilon_a()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.epsilon_a \"Go to Documentation\"), [wfn.epsilon_b()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.epsilon_b \"Go to Documentation\") | Returns $\\alpha$ (a) and $\\beta$ (b) orbital energies. (Identical for restricted orbitlas) |\n",
     "\n",
     "Note: The functions returning any of the matrices mentioned above (**C**, **D**, $\\boldsymbol{\\epsilon}$), actually\n",
-    "return instances of the `psi4.core.Matrix` class (noticing a pattern here?) and not viewable arrays.  To take a closer\n",
-    "look at these, then, we'll need to use NumPy's [`np.asarray()`](https://docs.scipy.org/doc/numpy/reference/generated\n",
-    "/numpy.asarray.html) function to create a view:\n",
-    "~~~python\n",
-    "C = np.asarray(wfn.Ca())\n",
-    "~~~\n",
-    "For more details on the relationship between the `psi4.core.Matrix` class\n",
-    "and NumPy, refer to the documentation [here](http://psicode.org/psi4manual/master/numpy.html \"Go to Documentation\")."
+    "return instances of the `psi4.core.Matrix` class (noticing a pattern here?) and not viewable arrays.  Fortunately,\n",
+    "the previous tutorial introduced how to modify these arrays Python-side, using NumPy views created through `np.asarray()`\n",
+    "or `.np`.\n",
+    "\n",
+    "The full list is quite extensive; however, this likely comprises the most utilized functions. It should be noted that the a stands for alpha and conversely the beta quantities can be accessed with the letter b. For now lets ensure that all computations have C1 symmetry; molecular symmetry can be utilized in psi4numpy computations, but adds significant complexity to the code."
    ]
   },
   {
@@ -258,23 +259,6 @@
    "outputs": [],
    "source": [
     "# Try out the wavefunction class member functions!\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A few more contents of a Wavefunction object after a SCF computation:\n",
-    "\n",
-    "| Quantity | Function(s) | Description |\n",
-    "|----------|-------------|-------------|\n",
-    "| Alpha Electrons | [wfn.nalpha()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.nalpha \"Go to Documentation\") | Returns number of alpha electrons of the wavefunction. |\n",
-    "| Beta Electrons | [wfn.nbeta()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.nbeta \"Go to Documentation\") | Returns number of beta electrons of the wavefunction. |\n",
-    "| Irreducible Representations | [wfn.nirrep()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.nirrep \"Go to Documentation\") | Returns number of irreducible representations (number of symmetry elements). Several objects can utilize molecular symmetry in the wavefunction. |\n",
-    "| Occupied Orbitals | [wfn.ndoccpi()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.ndoccpi \"Go to Documentation\") | Returns number of doubly occupied orbitals per irrep in the wavefunction. |\n",
-    "| Fock Matrix | [wfn.Fa()](http://psicode.org/psi4manual/master/psi4api.html#psi4.core.Wavefunction.Fa \"Go to Documentation\") | Returns the Fock matrix. |\n",
-    "\n",
-    "The full list is quite extensive; however, this likely comprises the most utilized functions. It should be noted that the a stands for alpha and conversely the beta quantities can be accessed with the letter b. For now lets ensure that all computations have C1 symmetry; molecular symmetry can be utilized in psi4numpy computations, but adds significant complexity to the code."
    ]
   }
  ],

--- a/Tutorials/01_Psi4NumPy-Basics/1d_mints_helper.ipynb
+++ b/Tutorials/01_Psi4NumPy-Basics/1d_mints_helper.ipynb
@@ -161,21 +161,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda root]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "conda-root-py"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/Tutorials/01_Psi4NumPy-Basics/1e_tensor_manipulation.ipynb
+++ b/Tutorials/01_Psi4NumPy-Basics/1e_tensor_manipulation.ipynb
@@ -32,8 +32,8 @@
     "\n",
     "Finally we also make use of Matrix notation:\n",
     "\\begin{align}\n",
-    "\\rm{Matrix}\\;\\;\\;  \\bf{D} &= \\bf{A B C} \\\\\n",
-    "\\rm{Einstein}\\;\\;\\;  D_{il} &= A_{ij} B_{jk} C_{kl}\n",
+    "{\\rm Matrix}\\;\\;\\;  \\bf{D} &= \\bf{A B C} \\\\\n",
+    "{\\rm Einstein}\\;\\;\\;  D_{il} &= A_{ij} B_{jk} C_{kl}\n",
     "\\end{align}\n",
     "\n",
     "Note that this notation is signified by the use of bold characters to denote matrices and consecutive matrices next to each other imply a chain of matrix multiplications! "
@@ -222,9 +222,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "On most machines the `np.dot` times are roughly ~3,000 times faster. The reason is two fold\n",
-    " - The `np.dot` routines typically call Basic Linear Algebra Subprograms (BLAS)[https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms]. The BLAS routines are highly optimized and threaded versions of the code.\n",
-    " - The `np.einsum` code will not factorize the code so that the overall cost is $\\mathcal{O}N^4$ (as there are four indices) rather than the factored $(\\bf{A B}) \\bf{C}$ which runs $\\mathcal{O}N^3$.\n",
+    "On most machines the `np.dot` times are roughly ~3,000 times faster. The reason is twofold:\n",
+    " - The `np.dot` routines typically call [Basic Linear Algebra Subprograms (BLAS)](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms). The BLAS routines are highly optimized and threaded versions of the code.\n",
+    " - The `np.einsum` code will not factorize the code so that the overall cost is ${\\cal O}(N^4)$ (as there are four indices) rather than the factored $(\\bf{A B}) \\bf{C}$ which runs ${\\cal O}(N^3)$.\n",
     " \n",
     "The first issue is difficult to overcome; however, the second issue can be resolved by the following:"
    ]
@@ -358,21 +358,33 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
   }
  },
  "nbformat": 4,

--- a/Tutorials/01_Psi4NumPy-Basics/1f_basis_sets.ipynb
+++ b/Tutorials/01_Psi4NumPy-Basics/1f_basis_sets.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basis Sets "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -234,9 +241,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [spandas15]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "Python [spandas15]"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
@@ -249,6 +256,18 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
    "version": "2.7.12"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Rectify issues in module 1 tutorials including:
- broken links
- unresolved LaTeX
- Merged split tables