### PR TITLE
EOM-CCSD

### DIFF
--- a/Coupled-Cluster/spin_free_CC/EOM_CCSD.py
+++ b/Coupled-Cluster/spin_free_CC/EOM_CCSD.py
@@ -1,0 +1,190 @@
+"""
+A Psi4 input script to compute excitation energies using EOM CCSD.
+This implementation shows how to use the Davidson method to partially
+diagonalize the (large) effective Hamiltonian matrix in order to find the lowest
+few excited states in the context of the EOM_CCSD method.
+
+A description of the Davidson algorithm can be found in Daniel Crawford's
+programming projects (#13)
+https://github.com/CrawfordGroup/ProgrammingProjects/tree/master/Project%2313
+
+Spin orbital sigma equations can be found in I. Shavitt and R. J. Bartlett,
+"Many-Body Methods in Chemistry and Physics: MBPT and Coupled-Cluster Theory".
+Cambridge University Press, 2009.
+
+Special thanks to Ashutosh Kumar for Hbar components and help with spin
+adaptation.
+"""
+
+__authors__ = "Andrew M. James"
+__credits__ = ["T. Daniel Crawford", "Ashutosh Kumar"]
+__copyright__ = "(c) 2017, The Psi4Numpy Developers"
+__license__ = "BSD-3-Clause"
+__date__ = "2018-1-17"
+
+from helper_cc import helper_ccenergy
+from helper_cc import helper_cchbar
+from helper_cc import helper_cceom
+import psi4
+import time
+import numpy as np
+np.set_printoptions(precision=5, linewidth=200, threshold=200, suppress=True)
+
+if __name__ == '__main__':
+    # EOM options
+    compare_psi4 = True
+    nroot = 3
+    nvec_per_root = 30
+    e_tol = 1.0e-6
+    max_iter = 80
+
+    # Psi4 setup
+    psi4.set_memory('2 GB')
+    psi4.core.set_output_file('output.dat', False)
+    # roots per irrep must be set to do the eom calculation with psi4
+    psi4.set_options({'basis': 'cc-pvdz', 'roots_per_irrep': [nroot]})
+    mol = psi4.geometry("""
+    O
+    H 1 1.1
+    H 1 1.1 2 104
+    noreorient
+    symmetry c1
+    """)
+
+    # Compute CCSD energy for required integrals and T-amplitudes
+    ccsd = helper_ccenergy(mol)
+    ccsd.compute_energy()
+
+    ccsd_cor_e = ccsd.ccsd_corr_e
+    ccsd_tot_e = ccsd.ccsd_e
+    print("\n")
+    print("{}{}".format('Final CCSD correlation energy:'.ljust(30, '.'),
+                        "{:16.15f}".format(ccsd_cor_e).rjust(20, '.')))
+    print("{}{}".format('Total CCSD energy:'.ljust(30, '.'),
+                        "{:16.15f}".format(ccsd_tot_e).rjust(20, ',')))
+
+    cchbar = helper_cchbar(ccsd)
+
+    # build CIS guess
+    ndocc = ccsd.ndocc
+    nvir = ccsd.nvirt
+    nov = ndocc * nvir
+    noovv = nov * nov
+    print("ndocc = {}".format(ndocc))
+    print("nvir = {}".format(nvir))
+    print("nov = {}".format(nov))
+
+    hbar_dim = nov + noovv
+    # L is the dimension of the guess space, we start with nroot*2 guesses
+    L = nroot * 2
+
+    # When L exceeds Lmax we will collapse the guess space so our sub-space
+    # diagonalization problem does not grow too large
+    Lmax = nroot * nvec_per_root
+
+    # An array to hold the excitation energies
+    theta = [0.0] * L
+
+    # build a helper_cceom object
+    cceom = helper_cceom(ccsd, cchbar)
+
+    # Get the approximate diagonal of Hbar
+    D = np.hstack((cceom.Dia.flatten(), cceom.Dijab.flatten()))
+
+    # We build a guess by selecting the lowest values of the approximate diagonal
+    # in the singles space one for each nroot*2 guesses we want,
+    # and we insert a guess vector with a 1 in the position corresponding to
+    # that single excitation and zeros everywhere else.
+    # This is a decent guess, more complicated one such as using CIS
+    # eigenvectors are more common in production level codes.
+    C_idx = D[:nov].argsort()[:nroot * 2]
+    C = np.eye(hbar_dim)[:, C_idx]
+
+    conv = False
+    eom_start = time.time()
+    for EOMCCSD_iter in range(0, max_iter + 1):
+        # QR decomposition ensures that the columns of C are orthogonal
+        C, R = np.linalg.qr(C)
+        L = C.shape[1]
+        theta_old = theta[:nroot]
+        print("EOMCCSD: Iter # {:>6} L = {}".format(EOMCCSD_iter, L))
+        # Build up the matrix S, holding the products Hbar*C, aka sigma vectors
+        S = np.zeros_like(C)
+        for i in range(L):
+            C1 = C[:nov, i].reshape(ndocc, nvir).copy()
+            C2 = C[nov:, i].reshape(ndocc, ndocc, nvir, nvir).copy()
+            S1 = cceom.build_sigma1(C1, C2)
+            S2 = cceom.build_sigma2(C1, C2)
+            S[:nov, i] += S1.flatten()
+            S[nov:, i] += S2.flatten()
+        # Build the subspace Hamiltonian
+        G = np.dot(C.T, S)
+        # Diagonalize it, and sort the eigenvector/eigenvalue pairs
+        THETA, alpha = np.linalg.eig(G)
+        idx = THETA.argsort()[:nroot]
+        theta = THETA[idx]
+        alpha = alpha[:, idx]
+        # This vector will hold the new guess vectors to add to our space
+        add_C = []
+
+        for j in range(nroot):
+            # Compute a residual vector "w" for each root we seek
+            # Note: for a more robust convergence criteria you can also check
+            # that the norm of the residual vector is below some threshold.
+            w = np.dot(S, alpha[:, j]) - theta[j] * np.dot(C, alpha[:, j])
+            # Precondition the residual vector to form a correction vector
+            q = w / (theta[j] - D[j])
+            # The correction vectors are added to the set of guesses after each
+            # iterations, so L the guess space dimension grows by nroot at each
+            # iteration
+            add_C.append(q)
+            de = abs(theta[j] - theta_old[j])
+            print(
+                "\tRoot {}: e = {:>20.12f} de = {:>20.12f} "
+                "|r| = {:>20.12f}".format(j, theta[j], de, np.linalg.norm(w)))
+
+        # check convergence
+        e_norm = np.linalg.norm(theta[:nroot] - theta_old)
+        if (e_norm < e_tol):
+            # If converged exit
+            conv = True
+            break
+
+        else:
+            # if we are not converged
+            # check the subspace dimension, if it has grown too large, collapse
+            # to nroot guesses using the current estimate of the eigenvectors
+            if L >= Lmax:
+                C = np.dot(C, alpha)
+                # These vectors will give the same eigenvalues at the next
+                # iteration so to avoid a false convergence we reset the theta
+                # vector to theta_old
+                theta = theta_old
+            else:
+                # if not we add the preconditioned residuals to the guess
+                # space, and continue. Note that the set will be orthogonalized
+                # at the start of the next iteration
+                Ctup = tuple(C[:, i] for i in range(L)) + tuple(add_C)
+                C = np.column_stack(Ctup)
+    if conv:
+        print("EOMCCSD Davidson iterations finished in {}s".format(
+            time.time() - eom_start))
+        print("Davidson Converged!")
+        print("Excitation Energies")
+        print("{:>6}  {:^20}  {:^20}".format("Root #", "Hartree", "eV"))
+        print("{:>6}  {:^20}  {:^20}".format("-" * 6, "-" * 20, "-" * 20))
+        for i in range(nroot):
+            print("{:>6}  {:>20.12f}  {:>20.12f}".format(i, theta[i], theta[i]
+                                                         * 22.211))
+    else:
+        psi4.core.clean()
+        raise Exception("EOMCCSD Failed -- Iterations exceeded")
+
+    # if requested compare values with psi4
+    if compare_psi4:
+        print("Checking against psi4....")
+        psi4.energy('eom-ccsd')
+        for i in range(nroot):
+            var_str = "CC ROOT {} CORRELATION ENERGY".format(i + 1)
+            e_ex = psi4.core.get_variable(var_str)
+            psi4.compare_values(e_ex, theta[i], 5, var_str)

--- a/Coupled-Cluster/spin_free_CC/EOM_CCSD.py
+++ b/Coupled-Cluster/spin_free_CC/EOM_CCSD.py
@@ -17,7 +17,7 @@ adaptation.
 """
 
 __authors__ = "Andrew M. James"
-__credits__ = ["T. Daniel Crawford", "Ashutosh Kumar"]
+__credits__ = ["T. Daniel Crawford", "Ashutosh Kumar", "Andrew M. James"]
 __copyright__ = "(c) 2017, The Psi4Numpy Developers"
 __license__ = "BSD-3-Clause"
 __date__ = "2018-1-17"

--- a/Coupled-Cluster/spin_free_CC/EOM_CCSD.py
+++ b/Coupled-Cluster/spin_free_CC/EOM_CCSD.py
@@ -30,161 +30,163 @@ import time
 import numpy as np
 np.set_printoptions(precision=5, linewidth=200, threshold=200, suppress=True)
 
-if __name__ == '__main__':
-    # EOM options
-    compare_psi4 = True
-    nroot = 3
-    nvec_per_root = 30
-    e_tol = 1.0e-6
-    max_iter = 80
 
-    # Psi4 setup
-    psi4.set_memory('2 GB')
-    psi4.core.set_output_file('output.dat', False)
-    # roots per irrep must be set to do the eom calculation with psi4
-    psi4.set_options({'basis': 'cc-pvdz', 'roots_per_irrep': [nroot]})
-    mol = psi4.geometry("""
-    O
-    H 1 1.1
-    H 1 1.1 2 104
-    noreorient
-    symmetry c1
-    """)
+# Psi4 setup
+psi4.set_memory('2 GB')
+psi4.core.set_output_file('output.dat', False)
+mol = psi4.geometry("""
+O
+H 1 1.1
+H 1 1.1 2 104
+noreorient
+symmetry c1
+""")
 
-    # Compute CCSD energy for required integrals and T-amplitudes
-    ccsd = helper_ccenergy(mol)
-    ccsd.compute_energy()
+# EOM options
+compare_psi4 = True
+nroot = 3
+nvec_per_root = 30
+e_tol = 1.0e-6
+max_iter = 80
 
-    ccsd_cor_e = ccsd.ccsd_corr_e
-    ccsd_tot_e = ccsd.ccsd_e
-    print("\n")
-    print("{}{}".format('Final CCSD correlation energy:'.ljust(30, '.'),
-                        "{:16.15f}".format(ccsd_cor_e).rjust(20, '.')))
-    print("{}{}".format('Total CCSD energy:'.ljust(30, '.'),
-                        "{:16.15f}".format(ccsd_tot_e).rjust(20, ',')))
+# roots per irrep must be set to do the eom calculation with psi4
+psi4.set_options({'basis': 'cc-pvdz', 'roots_per_irrep': [nroot]})
 
-    cchbar = helper_cchbar(ccsd)
+# Compute CCSD energy for required integrals and T-amplitudes
+ccsd = helper_ccenergy(mol)
+ccsd.compute_energy()
 
-    # build CIS guess
-    ndocc = ccsd.ndocc
-    nvir = ccsd.nvirt
-    nov = ndocc * nvir
-    noovv = nov * nov
-    print("ndocc = {}".format(ndocc))
-    print("nvir = {}".format(nvir))
-    print("nov = {}".format(nov))
+ccsd_cor_e = ccsd.ccsd_corr_e
+ccsd_tot_e = ccsd.ccsd_e
+print("\n")
+print("{}{}".format('Final CCSD correlation energy:'.ljust(30, '.'),
+                    "{:16.15f}".format(ccsd_cor_e).rjust(20, '.')))
+print("{}{}".format('Total CCSD energy:'.ljust(30, '.'),
+                    "{:16.15f}".format(ccsd_tot_e).rjust(20, ',')))
 
-    hbar_dim = nov + noovv
-    # L is the dimension of the guess space, we start with nroot*2 guesses
-    L = nroot * 2
+cchbar = helper_cchbar(ccsd)
 
-    # When L exceeds Lmax we will collapse the guess space so our sub-space
-    # diagonalization problem does not grow too large
-    Lmax = nroot * nvec_per_root
+# build CIS guess
+ndocc = ccsd.ndocc
+nvir = ccsd.nvirt
+nov = ndocc * nvir
+noovv = nov * nov
+print("ndocc = {}".format(ndocc))
+print("nvir = {}".format(nvir))
+print("nov = {}".format(nov))
 
-    # An array to hold the excitation energies
-    theta = [0.0] * L
+hbar_dim = nov + noovv
+# L is the dimension of the guess space, we start with nroot*2 guesses
+L = nroot * 2
 
-    # build a helper_cceom object
-    cceom = helper_cceom(ccsd, cchbar)
+# When L exceeds Lmax we will collapse the guess space so our sub-space
+# diagonalization problem does not grow too large
+Lmax = nroot * nvec_per_root
 
-    # Get the approximate diagonal of Hbar
-    D = np.hstack((cceom.Dia.flatten(), cceom.Dijab.flatten()))
+# An array to hold the excitation energies
+theta = [0.0] * L
 
-    # We build a guess by selecting the lowest values of the approximate diagonal
-    # in the singles space one for each nroot*2 guesses we want,
-    # and we insert a guess vector with a 1 in the position corresponding to
-    # that single excitation and zeros everywhere else.
-    # This is a decent guess, more complicated one such as using CIS
-    # eigenvectors are more common in production level codes.
-    C_idx = D[:nov].argsort()[:nroot * 2]
-    C = np.eye(hbar_dim)[:, C_idx]
+# build a helper_cceom object
+cceom = helper_cceom(ccsd, cchbar)
 
-    conv = False
-    eom_start = time.time()
-    for EOMCCSD_iter in range(0, max_iter + 1):
-        # QR decomposition ensures that the columns of C are orthogonal
-        C, R = np.linalg.qr(C)
-        L = C.shape[1]
-        theta_old = theta[:nroot]
-        print("EOMCCSD: Iter # {:>6} L = {}".format(EOMCCSD_iter, L))
-        # Build up the matrix S, holding the products Hbar*C, aka sigma vectors
-        S = np.zeros_like(C)
-        for i in range(L):
-            C1 = C[:nov, i].reshape(ndocc, nvir).copy()
-            C2 = C[nov:, i].reshape(ndocc, ndocc, nvir, nvir).copy()
-            S1 = cceom.build_sigma1(C1, C2)
-            S2 = cceom.build_sigma2(C1, C2)
-            S[:nov, i] += S1.flatten()
-            S[nov:, i] += S2.flatten()
-        # Build the subspace Hamiltonian
-        G = np.dot(C.T, S)
-        # Diagonalize it, and sort the eigenvector/eigenvalue pairs
-        THETA, alpha = np.linalg.eig(G)
-        idx = THETA.argsort()[:nroot]
-        theta = THETA[idx]
-        alpha = alpha[:, idx]
-        # This vector will hold the new guess vectors to add to our space
-        add_C = []
+# Get the approximate diagonal of Hbar
+D = np.hstack((cceom.Dia.flatten(), cceom.Dijab.flatten()))
 
-        for j in range(nroot):
-            # Compute a residual vector "w" for each root we seek
-            # Note: for a more robust convergence criteria you can also check
-            # that the norm of the residual vector is below some threshold.
-            w = np.dot(S, alpha[:, j]) - theta[j] * np.dot(C, alpha[:, j])
-            # Precondition the residual vector to form a correction vector
-            q = w / (theta[j] - D[j])
-            # The correction vectors are added to the set of guesses after each
-            # iterations, so L the guess space dimension grows by nroot at each
-            # iteration
-            add_C.append(q)
-            de = abs(theta[j] - theta_old[j])
-            print(
-                "\tRoot {}: e = {:>20.12f} de = {:>20.12f} "
-                "|r| = {:>20.12f}".format(j, theta[j], de, np.linalg.norm(w)))
+# We build a guess by selecting the lowest values of the approximate diagonal
+# in the singles space one for each nroot*2 guesses we want,
+# and we insert a guess vector with a 1 in the position corresponding to
+# that single excitation and zeros everywhere else.
+# This is a decent guess, more complicated one such as using CIS
+# eigenvectors are more common in production level codes.
+B_idx = D[:nov].argsort()[:nroot * 2]
+B = np.eye(hbar_dim)[:, B_idx]
 
-        # check convergence
-        e_norm = np.linalg.norm(theta[:nroot] - theta_old)
-        if (e_norm < e_tol):
-            # If converged exit
-            conv = True
-            break
+conv = False
+eom_start = time.time()
+# This is the start of the Davidson iterations
+for EOMCCSD_iter in range(0, max_iter + 1):
+    # QR decomposition ensures that the columns of B are orthogonal
+    B, R = np.linalg.qr(B)
+    L = B.shape[1]
+    theta_old = theta[:nroot]
+    print("EOMCCSD: Iter # {:>6} L = {}".format(EOMCCSD_iter, L))
+    # Build up the matrix S, holding the products Hbar*B, aka sigma vectors
+    S = np.zeros_like(B)
+    for i in range(L):
+        B1 = B[:nov, i].reshape(ndocc, nvir).copy()
+        B2 = B[nov:, i].reshape(ndocc, ndocc, nvir, nvir).copy()
+        S1 = cceom.build_sigma1(B1, B2)
+        S2 = cceom.build_sigma2(B1, B2)
+        S[:nov, i] += S1.flatten()
+        S[nov:, i] += S2.flatten()
+    # Build the subspace Hamiltonian
+    G = np.dot(B.T, S)
+    # Diagonalize it, and sort the eigenvector/eigenvalue pairs
+    theta, alpha = np.linalg.eig(G)
+    idx = theta.argsort()[:nroot]
+    theta = theta[idx]
+    alpha = alpha[:, idx]
+    # This vector will hold the new guess vectors to add to our space
+    add_B = []
 
-        else:
-            # if we are not converged
-            # check the subspace dimension, if it has grown too large, collapse
-            # to nroot guesses using the current estimate of the eigenvectors
-            if L >= Lmax:
-                C = np.dot(C, alpha)
-                # These vectors will give the same eigenvalues at the next
-                # iteration so to avoid a false convergence we reset the theta
-                # vector to theta_old
-                theta = theta_old
-            else:
-                # if not we add the preconditioned residuals to the guess
-                # space, and continue. Note that the set will be orthogonalized
-                # at the start of the next iteration
-                Ctup = tuple(C[:, i] for i in range(L)) + tuple(add_C)
-                C = np.column_stack(Ctup)
-    if conv:
-        print("EOMCCSD Davidson iterations finished in {}s".format(
-            time.time() - eom_start))
-        print("Davidson Converged!")
-        print("Excitation Energies")
-        print("{:>6}  {:^20}  {:^20}".format("Root #", "Hartree", "eV"))
-        print("{:>6}  {:^20}  {:^20}".format("-" * 6, "-" * 20, "-" * 20))
-        for i in range(nroot):
-            print("{:>6}  {:>20.12f}  {:>20.12f}".format(i, theta[i], theta[i]
-                                                         * 22.211))
+    for j in range(nroot):
+        # Compute a residual vector "w" for each root we seek
+        # Note: for a more robust convergence criteria you can also check
+        # that the norm of the residual vector is below some threshold.
+        w = np.dot(S, alpha[:, j]) - theta[j] * np.dot(B, alpha[:, j])
+        # Precondition the residual vector to form a correction vector
+        q = w / (theta[j] - D[j])
+        # The correction vectors are added to the set of guesses after each
+        # iterations, so L the guess space dimension grows by nroot at each
+        # iteration
+        add_B.append(q)
+        de = abs(theta[j] - theta_old[j])
+        print(
+            "    Root {}: e = {:>20.12f} de = {:>20.12f} "
+            "|r| = {:>20.12f}".format(j, theta[j], de, np.linalg.norm(w)))
+
+    # check convergence
+    e_norm = np.linalg.norm(theta[:nroot] - theta_old)
+    if (e_norm < e_tol):
+        # If converged exit
+        conv = True
+        break
+
     else:
-        psi4.core.clean()
-        raise Exception("EOMCCSD Failed -- Iterations exceeded")
+        # if we are not converged
+        # check the subspace dimension, if it has grown too large, collapse
+        # to nroot guesses using the current estimate of the eigenvectors
+        if L >= Lmax:
+            B = np.dot(B, alpha)
+            # These vectors will give the same eigenvalues at the next
+            # iteration so to avoid a false convergence we reset the theta
+            # vector to theta_old
+            theta = theta_old
+        else:
+            # if not we add the preconditioned residuals to the guess
+            # space, and continue. Note that the set will be orthogonalized
+            # at the start of the next iteration
+            Btup = tuple(B[:, i] for i in range(L)) + tuple(add_B)
+            B = np.column_stack(Btup)
+if conv:
+    print("EOMCCSD Davidson iterations finished in {}s".format(
+        time.time() - eom_start))
+    print("Davidson Converged!")
+    print("Excitation Energies")
+    print("{:>6}  {:^20}  {:^20}".format("Root #", "Hartree", "eV"))
+    print("{:>6}  {:^20}  {:^20}".format("-" * 6, "-" * 20, "-" * 20))
+    for i in range(nroot):
+        print("{:>6}  {:>20.12f}  {:>20.12f}".format(i, theta[i], theta[i]
+                                                     * 22.211))
+else:
+    psi4.core.clean()
+    raise Exception("EOMCCSD Failed -- Iterations exceeded")
 
-    # if requested compare values with psi4
-    if compare_psi4:
-        print("Checking against psi4....")
-        psi4.energy('eom-ccsd')
-        for i in range(nroot):
-            var_str = "CC ROOT {} CORRELATION ENERGY".format(i + 1)
-            e_ex = psi4.core.get_variable(var_str)
-            psi4.compare_values(e_ex, theta[i], 5, var_str)
+# if requested compare values with psi4
+if compare_psi4:
+    print("Checking against psi4....")
+    psi4.energy('eom-ccsd')
+    for i in range(nroot):
+        var_str = "CC ROOT {} CORRELATION ENERGY".format(i + 1)
+        e_ex = psi4.core.get_variable(var_str)
+        psi4.compare_values(e_ex, theta[i], 5, var_str)

--- a/Coupled-Cluster/spin_free_CC/EOM_CCSD.py
+++ b/Coupled-Cluster/spin_free_CC/EOM_CCSD.py
@@ -22,9 +22,9 @@ __copyright__ = "(c) 2017, The Psi4Numpy Developers"
 __license__ = "BSD-3-Clause"
 __date__ = "2018-1-17"
 
-from helper_cc import helper_ccenergy
-from helper_cc import helper_cchbar
-from helper_cc import helper_cceom
+from helper_cc import HelperCCEnergy
+from helper_cc import HelperCCHbar
+from helper_cc import HelperCCEom
 import psi4
 import time
 import numpy as np
@@ -53,7 +53,7 @@ max_iter = 80
 psi4.set_options({'basis': 'cc-pvdz', 'roots_per_irrep': [nroot]})
 
 # Compute CCSD energy for required integrals and T-amplitudes
-ccsd = helper_ccenergy(mol)
+ccsd = HelperCCEnergy(mol)
 ccsd.compute_energy()
 
 ccsd_cor_e = ccsd.ccsd_corr_e
@@ -64,7 +64,7 @@ print("{}{}".format('Final CCSD correlation energy:'.ljust(30, '.'),
 print("{}{}".format('Total CCSD energy:'.ljust(30, '.'),
                     "{:16.15f}".format(ccsd_tot_e).rjust(20, ',')))
 
-cchbar = helper_cchbar(ccsd)
+cchbar = HelperCCHbar(ccsd)
 
 # build CIS guess
 ndocc = ccsd.ndocc
@@ -86,8 +86,8 @@ Lmax = nroot * nvec_per_root
 # An array to hold the excitation energies
 theta = [0.0] * L
 
-# build a helper_cceom object
-cceom = helper_cceom(ccsd, cchbar)
+# build a HelperCCEom object
+cceom = HelperCCEom(ccsd, cchbar)
 
 # Get the approximate diagonal of Hbar
 D = np.hstack((cceom.Dia.flatten(), cceom.Dijab.flatten()))

--- a/Coupled-Cluster/spin_free_CC/helper_cc.py
+++ b/Coupled-Cluster/spin_free_CC/helper_cc.py
@@ -1604,6 +1604,18 @@ class HelperCCEom(object):
         ret : HelperCCEom
             An initialized HelperCCEom object
 
+        Notes
+        -----
+        Spin orbital sigma equations for EOMCCSDT can be found in:
+            I. Shavitt and R. J. Bartlett, "Many-Body Methods in Chemistry and
+            Physics: MBPT and Coupled-Cluster Theory", Cambridge University
+            Press, 2009.
+        The relevant contributions for EOMCCSD were extracted and the equations
+        spin adapted to arrive at the equations implemented in this class.
+
+        Special thanks to Ashutosh Kumar for Hbar components and help with spin
+        adaptation.
+
         """
         # Steal dimensions
         self.ndocc = ccsd.ndocc

--- a/Coupled-Cluster/spin_free_CC/helper_cc.py
+++ b/Coupled-Cluster/spin_free_CC/helper_cc.py
@@ -115,7 +115,7 @@ def ndot(input_string, op1, op2, prefactor=None):
         return np.einsum(tdot_result + '->' + output_ind, new_view)
 
 
-class helper_ccenergy(object):
+class HelperCCEnergy(object):
 
     def __init__(self, mol, freeze_core=False, memory=2):
 
@@ -555,9 +555,9 @@ class helper_ccenergy(object):
                     self.t2 += ci[num] * diis_vals_t2[num + 1]
 
             # End DIIS amplitude update
-            # End helper_ccenergy class
+            # End HelperCCEnergy class
 
-class helper_cchbar(object):
+class HelperCCHbar(object):
 
     def __init__(self, ccsd, memory=2):
 
@@ -764,7 +764,7 @@ class helper_cchbar(object):
         self.Hovoo -= ndot('mbef,ijef->mbij', tmp2, tmp1)
         return self.Hovoo
 
-class helper_cclambda(object):
+class HelperCCLambda(object):
 
     def __init__(self, ccsd, hbar):
 
@@ -983,7 +983,7 @@ class helper_cclambda(object):
 
 # End cclambda class
 
-class helper_ccpert(object):
+class HelperCCPert(object):
 
     def __init__(self, name, pert, ccsd, hbar, cclambda, memory=2):
 
@@ -1510,7 +1510,7 @@ class helper_ccpert(object):
                     z2 += ci[num] * diis_vals_z2[num + 1]
 
 # End ccpert class
-class helper_cclinresp(object):
+class HelperCCLinresp(object):
 
     def __init__(self, cclambda, ccpert_x, ccpert_y):
 
@@ -1581,7 +1581,7 @@ class helper_cclinresp(object):
 # End cclinresp class
 
 
-class helper_cceom(object):
+class HelperCCEom(object):
     """
     EOMCCSD helper class for spin adapted EOMCCSD
 
@@ -1589,20 +1589,20 @@ class helper_cceom(object):
 
     def __init__(self, ccsd, cchbar):
         """
-        Initializes the helper_cceom object
+        Initializes the HelperCCEom object
 
         Parameters
         ----------
-        ccsd: helper_ccsd object
+        ccsd: HelperCCSd object
             Energy should already be computed
 
-        cchbar: helper_cchbar object
+        cchbar: HelperCCHbar object
 
 
         Returns
         -------
-        ret : helper_cceom
-            An initialized helper_cceom object
+        ret : HelperCCEom
+            An initialized HelperCCEom object
 
         """
         # Steal dimensions

--- a/Coupled-Cluster/spin_free_CC/helper_cc.py
+++ b/Coupled-Cluster/spin_free_CC/helper_cc.py
@@ -1670,16 +1670,16 @@ class helper_cceom(object):
         return self.L[self.slice_dict[string[0]], self.slice_dict[string[1]],
                       self.slice_dict[string[2]], self.slice_dict[string[3]]]
 
-    def build_sigma1(self, C1, C2):
+    def build_sigma1(self, B1, B2):
         """
-        Compute the contributions to <ia|Hbar*C|0>
+        Compute the contributions to <ia|Hbar*B|0>
 
         Parameters
         ----------
-        C1: array like, shape(ndocc, nvir)
+        B1: array like, shape(ndocc, nvir)
           The first nsingles elements of a guess vector reshaped to (o,v)
 
-        C2: array like, shape(ndocc,ndocc,nvir,nvir)
+        B2: array like, shape(ndocc,ndocc,nvir,nvir)
           The last ndoubles elements of a guess vector reshaped to (o,o,v,v)
 
         Returns
@@ -1694,33 +1694,33 @@ class helper_cceom(object):
         >>> c,  = np.linalg.qr(c)
 
         >>> # Slice out the singles, doubles blocks of the first vector and reshape
-        >>> C1 = c[:,:nsingles].reshape(eom.ndocc, eom.nvir)
-        >>> C2 = c[:,nsingles:].reshape(eom.ndocc, eom.ndocc, eom.nvir, eom.nvir)
-        >>> S1 = eom.build_sigma1(C1, C2)
+        >>> B1 = c[:,:nsingles].reshape(eom.ndocc, eom.nvir)
+        >>> B2 = c[:,nsingles:].reshape(eom.ndocc, eom.ndocc, eom.nvir, eom.nvir)
+        >>> S1 = eom.build_sigma1(B1, B2)
 
         """
-        S1 = ndot('ie,ae->ia', C1, self.Hvv)
-        S1 -= ndot('mi,ma->ia', self.Hoo, C1)
-        S1 += ndot('maei,me->ia', self.Hovvo, C1, prefactor=2.0)
-        S1 += ndot('maie,me->ia', self.Hovov, C1, prefactor=-1.0)
-        S1 += ndot('miea,me->ia', C2, self.Hov, prefactor=2.0)
-        S1 += ndot('imea,me->ia', C2, self.Hov, prefactor=-1.0)
-        S1 += ndot('imef,amef->ia', C2, self.Hvovv, prefactor=2.0)
-        S1 += ndot('imef,amfe->ia', C2, self.Hvovv, prefactor=-1.0)
-        S1 -= ndot('mnie,mnae->ia', self.Hooov, C2, prefactor=2.0)
-        S1 -= ndot('nmie,mnae->ia', self.Hooov, C2, prefactor=-1.0)
+        S1 = ndot('ie,ae->ia', B1, self.Hvv)
+        S1 -= ndot('mi,ma->ia', self.Hoo, B1)
+        S1 += ndot('maei,me->ia', self.Hovvo, B1, prefactor=2.0)
+        S1 += ndot('maie,me->ia', self.Hovov, B1, prefactor=-1.0)
+        S1 += ndot('miea,me->ia', B2, self.Hov, prefactor=2.0)
+        S1 += ndot('imea,me->ia', B2, self.Hov, prefactor=-1.0)
+        S1 += ndot('imef,amef->ia', B2, self.Hvovv, prefactor=2.0)
+        S1 += ndot('imef,amfe->ia', B2, self.Hvovv, prefactor=-1.0)
+        S1 -= ndot('mnie,mnae->ia', self.Hooov, B2, prefactor=2.0)
+        S1 -= ndot('nmie,mnae->ia', self.Hooov, B2, prefactor=-1.0)
         return S1
 
-    def build_sigma2(self, C1, C2):
+    def build_sigma2(self, B1, B2):
         """
-        Compute the contributions to <ijab|Hbar*C|0>:
+        Compute the contributions to <ijab|Hbar*B|0>:
 
         Parameters
         ----------
-        C1: array like, shape(ndocc, nvir)
+        B1: array like, shape(ndocc, nvir)
           The first nsingles elements of a guess vector reshaped to (o,v)
 
-        C2: array like, shape(ndocc,ndocc,nvir,nvir)
+        B2: array like, shape(ndocc,ndocc,nvir,nvir)
           The last ndoubles elements of a guess vector reshaped to (o,o,v,v)
 
         Returns
@@ -1735,35 +1735,35 @@ class helper_cceom(object):
         >>> c,  = np.linalg.qr(c)
 
         >>> # Slice out the singles, doubles blocks of the first vector and reshape
-        >>> C1 = c[:,:nsingles].reshape(eom.ndocc, eom.nvir)
-        >>> C2 = c[:,nsingles:].reshape(eom.ndocc, eom.ndocc, eom.nvir, eom.nvir)
-        >>> S2 = eom.build_sigma2(C1, C2)
+        >>> B1 = c[:,:nsingles].reshape(eom.ndocc, eom.nvir)
+        >>> B2 = c[:,nsingles:].reshape(eom.ndocc, eom.ndocc, eom.nvir, eom.nvir)
+        >>> S2 = eom.build_sigma2(B1, B2)
 
         """
-        S_2 = ndot('ie,abej->ijab', C1, self.Hvvvo)
-        S_2 -= ndot('mbij,ma->ijab', self.Hovoo, C1)
+        S_2 = ndot('ie,abej->ijab', B1, self.Hvvvo)
+        S_2 -= ndot('mbij,ma->ijab', self.Hovoo, B1)
 
-        Zvv = ndot("amef,mf->ae", self.Hvovv, C1, prefactor=2.0)
-        Zvv += ndot("amfe,mf->ae", self.Hvovv, C1, prefactor=-1.0)
-        Zvv -= ndot('nmaf,nmef->ae', C2, self.get_L('oovv'))
+        Zvv = ndot("amef,mf->ae", self.Hvovv, B1, prefactor=2.0)
+        Zvv += ndot("amfe,mf->ae", self.Hvovv, B1, prefactor=-1.0)
+        Zvv -= ndot('nmaf,nmef->ae', B2, self.get_L('oovv'))
         S_2 += ndot('ijeb,ae->ijab', self.t2, Zvv)
 
-        Zoo = ndot('mnie,ne->mi', self.Hooov, C1, prefactor=-2.0)
-        Zoo -= ndot('nmie,ne->mi', self.Hooov, C1, prefactor=-1.0)
-        Zoo -= ndot('mnef,inef->mi', self.get_L('oovv'), C2)
+        Zoo = ndot('mnie,ne->mi', self.Hooov, B1, prefactor=-2.0)
+        Zoo -= ndot('nmie,ne->mi', self.Hooov, B1, prefactor=-1.0)
+        Zoo -= ndot('mnef,inef->mi', self.get_L('oovv'), B2)
         S_2 += ndot('mi,mjab->ijab', Zoo, self.t2)
 
-        S_2 += ndot('ijeb,ae->ijab', C2, self.Hvv)
-        S_2 -= ndot('mi,mjab->ijab', self.Hoo, C2)
+        S_2 += ndot('ijeb,ae->ijab', B2, self.Hvv)
+        S_2 -= ndot('mi,mjab->ijab', self.Hoo, B2)
 
-        S_2 += ndot('mnij,mnab->ijab', self.Hoooo, C2, prefactor=0.5)
-        S_2 += ndot('ijef,abef->ijab', C2, self.Hvvvv, prefactor=0.5)
+        S_2 += ndot('mnij,mnab->ijab', self.Hoooo, B2, prefactor=0.5)
+        S_2 += ndot('ijef,abef->ijab', B2, self.Hvvvv, prefactor=0.5)
 
-        S_2 -= ndot('imeb,maje->ijab', C2, self.Hovov)
-        S_2 -= ndot('imea,mbej->ijab', C2, self.Hovvo)
+        S_2 -= ndot('imeb,maje->ijab', B2, self.Hovov)
+        S_2 -= ndot('imea,mbej->ijab', B2, self.Hovvo)
 
-        S_2 += ndot('miea,mbej->ijab', C2, self.Hovvo, prefactor=2.0)
-        S_2 += ndot('miea,mbje->ijab', C2, self.Hovov, prefactor=-1.0)
+        S_2 += ndot('miea,mbej->ijab', B2, self.Hovvo, prefactor=2.0)
+        S_2 += ndot('miea,mbje->ijab', B2, self.Hovov, prefactor=-1.0)
         return S_2 + S_2.swapaxes(0, 1).swapaxes(2, 3)
 
 if __name__ == "__main__":

--- a/Coupled-Cluster/spin_free_CC/helper_cc.py
+++ b/Coupled-Cluster/spin_free_CC/helper_cc.py
@@ -1,10 +1,10 @@
-# A simple Psi4 script to compute CCSD linear response properties (spin-free) from 
+# A simple Psi4 script to compute CCSD linear response properties (spin-free) from
 # RHF reference Scipy and numpy python modules are required
 # Algorithms were taken directly from Daniel Crawford's programming website:
 # http://github.com/CrawfordGroup/ProgrammingProjects
-# Equations were spin-adapted using unitary group approach used in the moelcular 
-# electronic structure theory. 
-# Special thanks to Dr. T Daniel Crawford for help in spin-adaptation of 
+# Equations were spin-adapted using unitary group approach used in the molecular
+# electronic structure theory.
+# Special thanks to Dr. T Daniel Crawford for help in spin-adaptation of
 # the equations and Lori Burns for integral help
 #
 # Created by: Ashutosh Kumar, Daniel G. A. Smith.
@@ -176,7 +176,7 @@ class helper_ccenergy(object):
         H = np.asarray(self.mints.ao_kinetic()) + np.asarray(self.mints.ao_potential())
         self.nmo = H.shape[0]
 
-        # Update H, transform to MO basis 
+        # Update H, transform to MO basis
         H = np.einsum('uj,vi,uv', self.npC, self.npC, H)
 
         print('Starting AO ->  MO transformation...')
@@ -186,7 +186,8 @@ class helper_ccenergy(object):
         if memory_footprint > self.memory:
             psi.clean()
             raise Exception("Estimated memory utilization (%4.2f GB) exceeds numpy_memory \
-                            limit of %4.2f GB." % (memory_footprint, self.memory))
+                            limit of %4.2f GB."
+                                                % (memory_footprint, self.memory))
 
         # Integral generation from Psi4's MintsHelper
         self.MO = np.asarray(self.mints.mo_eri(self.C, self.C, self.C, self.C))
@@ -194,7 +195,7 @@ class helper_ccenergy(object):
         print("Size of the ERI tensor is %4.2f GB, %d basis functions." % (ERI_Size, self.nmo))
 
         # Update nocc and nvirt
-        self.nocc = self.ndocc 
+        self.nocc = self.ndocc
         self.nvirt = self.nmo - self.nocc - self.nfzc
 
         # Make slices
@@ -341,7 +342,7 @@ class helper_ccenergy(object):
 
     def build_Zmbij(self):
         Zmbij = 0
-        Zmbij += ndot('mbef,ijef->mbij', self.get_MO('ovvv'), self.build_tau())	
+        Zmbij += ndot('mbef,ijef->mbij', self.get_MO('ovvv'), self.build_tau())
         return Zmbij
 
     def update(self):
@@ -378,24 +379,24 @@ class helper_ccenergy(object):
         r_T2 += tmp.swapaxes(0,1).swapaxes(2,3)
 
         # P^(ab)_(ij) {-0.5 * t_ijae t_mb Fme_me }
-        tmp = ndot('mb,me->be', self.t1, Fme) 
-        first = ndot('ijae,be->ijab', self.t2, tmp, prefactor=0.5)	
+        tmp = ndot('mb,me->be', self.t1, Fme)
+        first = ndot('ijae,be->ijab', self.t2, tmp, prefactor=0.5)
         r_T2 -= first
         r_T2 -= first.swapaxes(0,1).swapaxes(2,3)
 
         # P^(ab)_(ij) {-t_imab Fmi_mj }
-        tmp = ndot('imab,mj->ijab', self.t2, Fmi, prefactor=1.0) 
+        tmp = ndot('imab,mj->ijab', self.t2, Fmi, prefactor=1.0)
         r_T2 -= tmp
         r_T2 -= tmp.swapaxes(0,1).swapaxes(2,3)
 
-	# P^(ab)_(ij) {-0.5 * t_imab t_je Fme_me }
+        # P^(ab)_(ij) {-0.5 * t_imab t_je Fme_me }
         tmp = ndot('je,me->jm', self.t1, Fme)
-        first = ndot('imab,jm->ijab', self.t2, tmp, prefactor=0.5)      
+        first = ndot('imab,jm->ijab', self.t2, tmp, prefactor=0.5)
         r_T2 -= first
         r_T2 -= first.swapaxes(0,1).swapaxes(2,3)
-    
-	
-	# tau_mnab Wmnij_mnij + tau_ijef <ab|ef> }
+
+
+        # tau_mnab Wmnij_mnij + tau_ijef <ab|ef> }
         tmp_tau = self.build_tau()
         Wmnij = self.build_Wmnij()
         Wmbej = self.build_Wmbej()
@@ -410,13 +411,13 @@ class helper_ccenergy(object):
         tmp = ndot('ie,abej->ijab', self.t1, self.get_MO('vvvo'), prefactor=1.0)
         r_T2 += tmp
         r_T2 += tmp.swapaxes(0,1).swapaxes(2,3)
-        
+
         # P^(ab)_(ij) {-t_ma <mb|ij> }
         tmp = ndot('ma,mbij->ijab', self.t1, self.get_MO('ovoo'), prefactor=1.0)
         r_T2 -= tmp
         r_T2 -= tmp.swapaxes(0,1).swapaxes(2,3)
-	
-	# P...
+
+        # P...
         r_T2 += ndot('imae,mbej->ijab', self.t2, Wmbej, prefactor=1.0)
         r_T2 += ndot('imea,mbej->ijab', self.t2, Wmbej, prefactor=-1.0)
 
@@ -431,8 +432,8 @@ class helper_ccenergy(object):
 
         r_T2 += ndot('jmbe,maei->ijab', self.t2, Wmbej, prefactor=1.0)
         r_T2 += ndot('jmeb,maei->ijab', self.t2, Wmbej, prefactor=-1.0)
-	
-	# P....
+
+        # P....
 
         tmp = ndot('ie,ma->imea', self.t1, self.t1)
         r_T2 -= ndot('imea,mbej->ijab', tmp, self.get_MO('ovvo'))
@@ -446,8 +447,8 @@ class helper_ccenergy(object):
         tmp = ndot('je,mb->jmeb', self.t1, self.t1)
         r_T2 -= ndot('jmeb,maei->ijab', tmp, self.get_MO('ovvo'))
 
-        r_T2 -= ndot('ma,mbij->ijab', self.t1, Zmbij)	
-        r_T2 -= ndot('ma,mbij->jiba', self.t1, Zmbij)	
+        r_T2 -= ndot('ma,mbij->ijab', self.t1, Zmbij)
+        r_T2 -= ndot('ma,mbij->jiba', self.t1, Zmbij)
 
 
         ### Update T1 and T2 amplitudes
@@ -554,7 +555,7 @@ class helper_ccenergy(object):
                     self.t2 += ci[num] * diis_vals_t2[num + 1]
 
             # End DIIS amplitude update
-# End helper_ccenergy class
+            # End helper_ccenergy class
 
 class helper_cchbar(object):
 
@@ -917,7 +918,7 @@ class helper_cclambda(object):
 
             self.update()
 
-            # Compute lambda 
+            # Compute lambda
             pseudoenergy = self.pseudoenergy()
 
             # Print CCLAMBDA iteration information
@@ -1267,7 +1268,7 @@ class helper_ccpert(object):
         r_y1 -= ndot('mina,mn->ia', self.Hooov, self.build_Goo(self.t2, self.y2), prefactor=2.0)
         r_y1 -= ndot('imna,mn->ia', self.Hooov, self.build_Goo(self.t2, self.y2), prefactor=-1.0)
 
-        # Inhomogenous terms 
+        # Inhomogenous terms
 
 
         r_y1 += ndot('imae,me->ia', self.get_L('oovv'), self.x1, prefactor=2.0)
@@ -1311,7 +1312,7 @@ class helper_ccpert(object):
 
         ## 3-body terms over
 
-        ## X2 * L2 terms 
+        ## X2 * L2 terms
 
         r_y1  -=  ndot('mi,ma->ia', self.build_Goo(self.x2, self.l2), self.Hov)  # t
         r_y1  +=  ndot('ie,ea->ia', self.Hov, self.build_Gvv(self.x2, self.l2))  # t
@@ -1331,9 +1332,9 @@ class helper_ccpert(object):
         r_y1  -=  ndot('mioe,oame->ia', self.Hooov, self.build_l2x2ovov_3(self.l2, self.x2), prefactor=-1.0) # t
 
 
-        # y1 over !! 
+        # y1 over !!
 
-        # Homogenous terms of Y2 equations 
+        # Homogenous terms of Y2 equations
 
         r_y2 = 0.5 * self.omega * self.y2.copy()
         r_y2 += ndot('ia,jb->ijab', self.y1, self.Hov, prefactor=2.0)
@@ -1353,7 +1354,7 @@ class helper_ccpert(object):
         r_y2 += ndot('ijeb,ae->ijab', self.get_L('oovv'), self.build_Gvv(self.y2, self.t2))
         r_y2 -= ndot('mi,mjab->ijab', self.build_Goo(self.t2, self.y2), self.get_L('oovv'))
 
-        # InHomogenous terms of Y2 equations 
+        # InHomogenous terms of Y2 equations
 
         r_y2 += ndot('ia,jb->ijab', self.l1, self.build_Aov(), prefactor=2.0) # o
         r_y2 -= ndot('ja,ib->ijab', self.l1, self.build_Aov()) # o
@@ -1390,16 +1391,16 @@ class helper_ccpert(object):
         r_y2 += ndot('ibne,njea->ijab', self.build_l2x2ovov_2(self.l2, self.x2), self.get_MO('oovv'), prefactor=0.5) # x same.2
         r_y2 += ndot('ijfe,baef->ijab', self.get_MO('oovv'), self.build_l2x2vvvv(self.l2, self.x2), prefactor=0.5) # x
 
-        r_y2 -= ndot('inae,jbne->ijab', self.get_L('oovv'), self.build_l2x2ovov_2(self.l2, self.x2), prefactor=1.0) # x 
-        r_y2 -= ndot('in,jnba->ijab', self.build_Goo(self.get_L('oovv'), self.x2), self.l2, prefactor=1.0) # x 
-        r_y2 += ndot('ijfb,af->ijab', self.l2, self.build_Gvv(self.get_L('oovv'), self.x2), prefactor=1.0) # x 
+        r_y2 -= ndot('inae,jbne->ijab', self.get_L('oovv'), self.build_l2x2ovov_2(self.l2, self.x2), prefactor=1.0) # x
+        r_y2 -= ndot('in,jnba->ijab', self.build_Goo(self.get_L('oovv'), self.x2), self.l2, prefactor=1.0) # x
+        r_y2 += ndot('ijfb,af->ijab', self.l2, self.build_Gvv(self.get_L('oovv'), self.x2), prefactor=1.0) # x
 
-        r_y2 += ndot('ijae,be->ijab', self.get_L('oovv'), self.build_Gvv(self.l2, self.x2), prefactor=1.0) # x 
-        r_y2 -= ndot('imab,jm->ijab', self.get_L('oovv'), self.build_Goo(self.l2, self.x2), prefactor=1.0) # x 
-        r_y2 -= ndot('ibme,mjea->ijab', self.build_l2x2ovov_3(self.l2, self.x2), self.get_L('oovv'), prefactor=1.0) # x 
+        r_y2 += ndot('ijae,be->ijab', self.get_L('oovv'), self.build_Gvv(self.l2, self.x2), prefactor=1.0) # x
+        r_y2 -= ndot('imab,jm->ijab', self.get_L('oovv'), self.build_Goo(self.l2, self.x2), prefactor=1.0) # x
+        r_y2 -= ndot('ibme,mjea->ijab', self.build_l2x2ovov_3(self.l2, self.x2), self.get_L('oovv'), prefactor=1.0) # x
 
 
-        r_y2 += ndot('imae,jbme->ijab', self.get_L('oovv'), self.build_l2x2ovov_3(self.l2, self.x2), prefactor=2.0) # x 
+        r_y2 += ndot('imae,jbme->ijab', self.get_L('oovv'), self.build_l2x2ovov_3(self.l2, self.x2), prefactor=2.0) # x
         self.y1 += r_y1/self.Dia
         tmp = r_y2
         tmp += r_y2.swapaxes(0,1).swapaxes(2,3)
@@ -1409,9 +1410,9 @@ class helper_ccpert(object):
         polar1 = 0
         polar2 = 0
         if hand == 'right':
-            z1 = self.x1 ; z2 = self.x2
+            z1 = self.x1;  z2 = self.x2
         else:
-            z1 = self.y1 ; z2 = self.y2
+            z1 = self.y1;  z2 = self.y2
         polar1 += ndot('ia,ai->', z1, self.build_Avo(), prefactor=2.0)
         polar2 += ndot('ijab,abij->', z2, self.build_Avvoo(), prefactor=4.0)
         polar2 += ndot('ijba,abij->', z2, self.build_Avvoo(), prefactor=-2.0)
@@ -1422,9 +1423,9 @@ class helper_ccpert(object):
     def solve(self, hand, r_conv=1.e-13, maxiter=50, max_diis=8):
         ### Setup DIIS
         if hand == 'right':
-            z1 = self.x1 ; z2 = self.x2
+            z1 = self.x1;  z2 = self.x2
         else:
-            z1 = self.y1 ; z2 = self.y2
+            z1 = self.y1;  z2 = self.y2
 
         diis_vals_z1 = [z1.copy()]
         diis_vals_z2 = [z2.copy()]
@@ -1578,6 +1579,192 @@ class helper_cclinresp(object):
         return -1.0*(self.polar1 + self.polar2)
 
 # End cclinresp class
+
+
+class helper_cceom(object):
+    """
+    EOMCCSD helper class for spin adapted EOMCCSD
+
+    """
+
+    def __init__(self, ccsd, cchbar):
+        """
+        Initializes the helper_cceom object
+
+        Parameters
+        ----------
+        ccsd: helper_ccsd object
+            Energy should already be computed
+
+        cchbar: helper_cchbar object
+
+
+        Returns
+        -------
+        ret : helper_cceom
+            An initialized helper_cceom object
+
+        """
+        # Steal dimensions
+        self.ndocc = ccsd.ndocc
+        self.nmo = ccsd.nmo
+        self.nfzc = 0
+        self.nocc = ccsd.ndocc
+        self.nvir = ccsd.nmo - ccsd.nocc - ccsd.nfzc
+        self.nsingles = self.ndocc * self.nvir
+        self.ndoubles = self.ndocc * self.ndocc * self.nvir * self.nvir
+
+        # Steal integrals/amps from ccsd
+        self.MO = ccsd.MO
+        self.F = ccsd.F
+        self.t1 = ccsd.t1
+        self.t2 = ccsd.t2
+
+        # Steal "ova" translation
+        self.slice_nfzc = cchbar.slice_nfzc
+        self.slice_o = cchbar.slice_o
+        self.slice_v = cchbar.slice_v
+        self.slice_a = cchbar.slice_a
+        self.slice_dict = cchbar.slice_dict
+
+        # Steal Hbar blocks
+        self.Hov = cchbar.Hov
+        self.Hoo = cchbar.Hoo
+        self.Hvv = cchbar.Hvv
+        self.Hoooo = cchbar.Hoooo
+        self.Hvvvv = cchbar.Hvvvv
+        self.Hvovv = cchbar.Hvovv
+        self.Hooov = cchbar.Hooov
+        self.Hovvo = cchbar.Hovvo
+        self.Hovov = cchbar.Hovov
+        self.Hvvvo = cchbar.Hvvvo
+        self.Hovoo = cchbar.Hovoo
+
+        # Steal L integrals (L[pqrs] = 2*MO[pqrs] - MO[pqsr])
+        self.L = cchbar.L
+
+        # Build Approximate Diagonal of Hbar
+        self.Dia = self.Hoo.diagonal().reshape(-1, 1) - self.Hvv.diagonal()
+        self.Dijab = self.Hoo.diagonal().reshape(
+            -1, 1, 1, 1) + self.Hoo.diagonal().reshape(
+                -1, 1, 1) - self.Hvv.diagonal().reshape(
+                    -1, 1) - self.Hvv.diagonal()
+
+    def get_MO(self, string):
+        if len(string) != 4:
+            psi4.core.clean()
+            raise Exception('get_MO: string %s must have 4 elements.' % string)
+        return self.MO[self.slice_dict[string[0]], self.slice_dict[string[1]],
+                       self.slice_dict[string[2]], self.slice_dict[string[3]]]
+
+    def get_F(self, string):
+        if len(string) != 2:
+            psi4.core.clean()
+            raise Exception('get_F: string %s must have 4 elements.' % string)
+        return self.F[self.slice_dict[string[0]], self.slice_dict[string[1]]]
+
+    def get_L(self, string):
+        if len(string) != 4:
+            psi4.core.clean()
+            raise Exception('get_L: string %s must have 4 elements.' % string)
+        return self.L[self.slice_dict[string[0]], self.slice_dict[string[1]],
+                      self.slice_dict[string[2]], self.slice_dict[string[3]]]
+
+    def build_sigma1(self, C1, C2):
+        """
+        Compute the contributions to <ia|Hbar*C|0>
+
+        Parameters
+        ----------
+        C1: array like, shape(ndocc, nvir)
+          The first nsingles elements of a guess vector reshaped to (o,v)
+
+        C2: array like, shape(ndocc,ndocc,nvir,nvir)
+          The last ndoubles elements of a guess vector reshaped to (o,o,v,v)
+
+        Returns
+        -------
+        S1: ndarray shape(ndocc, nvir)
+
+        Examples
+        --------
+
+        >>> # Get some vectors as cols of a 2D numpy array and orthogonalize them
+        >>> c  = np.random.rand(eom.nsingles + eom.ndoubles, 2)
+        >>> c,  = np.linalg.qr(c)
+
+        >>> # Slice out the singles, doubles blocks of the first vector and reshape
+        >>> C1 = c[:,:nsingles].reshape(eom.ndocc, eom.nvir)
+        >>> C2 = c[:,nsingles:].reshape(eom.ndocc, eom.ndocc, eom.nvir, eom.nvir)
+        >>> S1 = eom.build_sigma1(C1, C2)
+
+        """
+        S1 = ndot('ie,ae->ia', C1, self.Hvv)
+        S1 -= ndot('mi,ma->ia', self.Hoo, C1)
+        S1 += ndot('maei,me->ia', self.Hovvo, C1, prefactor=2.0)
+        S1 += ndot('maie,me->ia', self.Hovov, C1, prefactor=-1.0)
+        S1 += ndot('miea,me->ia', C2, self.Hov, prefactor=2.0)
+        S1 += ndot('imea,me->ia', C2, self.Hov, prefactor=-1.0)
+        S1 += ndot('imef,amef->ia', C2, self.Hvovv, prefactor=2.0)
+        S1 += ndot('imef,amfe->ia', C2, self.Hvovv, prefactor=-1.0)
+        S1 -= ndot('mnie,mnae->ia', self.Hooov, C2, prefactor=2.0)
+        S1 -= ndot('nmie,mnae->ia', self.Hooov, C2, prefactor=-1.0)
+        return S1
+
+    def build_sigma2(self, C1, C2):
+        """
+        Compute the contributions to <ijab|Hbar*C|0>:
+
+        Parameters
+        ----------
+        C1: array like, shape(ndocc, nvir)
+          The first nsingles elements of a guess vector reshaped to (o,v)
+
+        C2: array like, shape(ndocc,ndocc,nvir,nvir)
+          The last ndoubles elements of a guess vector reshaped to (o,o,v,v)
+
+        Returns
+        -------
+        S2: ndarray shape(ndocc, ndocc, nvir, nvir)
+
+        Examples
+        --------
+
+        >>> # Get some vectors as cols of a 2D numpy array and orthogonalize them
+        >>> c  = np.random.rand(eom.nsingles + eom.ndoubles, 2)
+        >>> c,  = np.linalg.qr(c)
+
+        >>> # Slice out the singles, doubles blocks of the first vector and reshape
+        >>> C1 = c[:,:nsingles].reshape(eom.ndocc, eom.nvir)
+        >>> C2 = c[:,nsingles:].reshape(eom.ndocc, eom.ndocc, eom.nvir, eom.nvir)
+        >>> S2 = eom.build_sigma2(C1, C2)
+
+        """
+        S_2 = ndot('ie,abej->ijab', C1, self.Hvvvo)
+        S_2 -= ndot('mbij,ma->ijab', self.Hovoo, C1)
+
+        Zvv = ndot("amef,mf->ae", self.Hvovv, C1, prefactor=2.0)
+        Zvv += ndot("amfe,mf->ae", self.Hvovv, C1, prefactor=-1.0)
+        Zvv -= ndot('nmaf,nmef->ae', C2, self.get_L('oovv'))
+        S_2 += ndot('ijeb,ae->ijab', self.t2, Zvv)
+
+        Zoo = ndot('mnie,ne->mi', self.Hooov, C1, prefactor=-2.0)
+        Zoo -= ndot('nmie,ne->mi', self.Hooov, C1, prefactor=-1.0)
+        Zoo -= ndot('mnef,inef->mi', self.get_L('oovv'), C2)
+        S_2 += ndot('mi,mjab->ijab', Zoo, self.t2)
+
+        S_2 += ndot('ijeb,ae->ijab', C2, self.Hvv)
+        S_2 -= ndot('mi,mjab->ijab', self.Hoo, C2)
+
+        S_2 += ndot('mnij,mnab->ijab', self.Hoooo, C2, prefactor=0.5)
+        S_2 += ndot('ijef,abef->ijab', C2, self.Hvvvv, prefactor=0.5)
+
+        S_2 -= ndot('imeb,maje->ijab', C2, self.Hovov)
+        S_2 -= ndot('imea,mbej->ijab', C2, self.Hovvo)
+
+        S_2 += ndot('miea,mbej->ijab', C2, self.Hovvo, prefactor=2.0)
+        S_2 += ndot('miea,mbje->ijab', C2, self.Hovov, prefactor=-1.0)
+        return S_2 + S_2.swapaxes(0, 1).swapaxes(2, 3)
 
 if __name__ == "__main__":
     arr4 = np.random.rand(4, 4, 4, 4)

--- a/Coupled-Cluster/spin_free_CC/polar.py
+++ b/Coupled-Cluster/spin_free_CC/polar.py
@@ -1,10 +1,10 @@
 import time
 import numpy as np
-from helper_cc import helper_ccenergy
-from helper_cc import helper_cchbar
-from helper_cc import helper_cclambda
-from helper_cc import helper_ccpert
-from helper_cc import helper_cclinresp
+from helper_cc import HelperCCEnergy
+from helper_cc import HelperCCHbar
+from helper_cc import HelperCCLambda
+from helper_cc import HelperCCPert
+from helper_cc import HelperCCLinresp
 
 np.set_printoptions(precision=15, linewidth=200, suppress=True)
 import psi4
@@ -29,7 +29,7 @@ psi4.set_options({'basis': 'sto-3g'})
 compare_psi4 = True
 
 # Compute CCSD
-ccsd = helper_ccenergy(mol, memory=2)
+ccsd = HelperCCEnergy(mol, memory=2)
 ccsd.compute_energy()
 
 CCSDcorr_E = ccsd.ccsd_corr_e
@@ -38,9 +38,9 @@ CCSD_E = ccsd.ccsd_e
 print('\nFinal CCSD correlation energy:          % 16.15f' % CCSDcorr_E)
 print('Total CCSD energy:                      % 16.15f' % CCSD_E)
 
-cchbar = helper_cchbar(ccsd)
+cchbar = HelperCCHbar(ccsd)
 
-cclambda = helper_cclambda(ccsd,cchbar)
+cclambda = HelperCCLambda(ccsd,cchbar)
 cclambda.compute_lambda()
 omega = 0.0
 
@@ -53,12 +53,12 @@ polar_AB = {}
 for i in range(0,3):
     string = "MU_" + cart[i]
     mu[string] = np.einsum('uj,vi,uv', ccsd.npC, ccsd.npC, np.asarray(ccsd.mints.ao_dipole()[i]))
-    ccpert[string] = helper_ccpert(string, mu[string], ccsd, cchbar, cclambda, omega)
+    ccpert[string] = HelperCCPert(string, mu[string], ccsd, cchbar, cclambda, omega)
     print('\nsolving right hand perturbed amplitudes for %s\n' % string)
     ccpert[string].solve('right')
     print('\nsolving left hand perturbed amplitudes for %s\n'% string)
     ccpert[string].solve('left')
-    
+
 print('\n Calculating Polarizability tensor:\n')
 
 for a in range(0,3):
@@ -66,7 +66,7 @@ for a in range(0,3):
     for b in range(0,3):
         str_b = "MU_" + cart[b]
         str_ab = "<<" + str_a + ";" + str_b + ">>"
-        polar_AB[str_ab]= helper_cclinresp(cclambda, ccpert[str_a], ccpert[str_b]).linresp()    
+        polar_AB[str_ab]= HelperCCLinresp(cclambda, ccpert[str_a], ccpert[str_b]).linresp()
 
 print('\nPolarizability tensor (symmetrized):\n')
 
@@ -80,7 +80,3 @@ for a in range(0,3):
         polar_AB[str_ab] = value
         polar_AB[str_ba] = value
         print(str_ab + ":" + str(value))
-    
-    
-    
-

--- a/tests/test_RI_CC.py
+++ b/tests/test_RI_CC.py
@@ -17,5 +17,9 @@ def test_CCSD_T(workspace):
     exe_py(workspace, tdir, 'CCSD_T')
 
 
+def test_EOM_CCSD(workspace):
+    exe_py(workspace, tdir+'/spin_free_CC','EOM_CCSD')
+
+
 #def test_TD_CCSD(workspace):
 #    exe_py(workspace, tdir, 'TD-CCSD')


### PR DESCRIPTION
Adds modules for computing Hbar elements and doing a simple EOMCCSD computation. 


This can be very slow, but if you have access to Numpy 1.12 adding the kwarg optimize=True in the contractions for evaluating the sigma vectors will save a lot of time. 

The Davidson solver is not very robust and for some some cases where the number of roots requested involves the first one or two roots of a triplet set it will fail or converge to nonsensical complex roots. 

Any suggestions on how to improve the efficiency or the stability of the Davidson routine would be appreciated 