### PR TITLE
Bug fix in SAPT0(ROHF).

### DIFF
--- a/Symmetry-Adapted-Perturbation-Theory/helper_SAPT.py
+++ b/Symmetry-Adapted-Perturbation-Theory/helper_SAPT.py
@@ -219,7 +219,7 @@ class helper_SAPT(object):
 
         shape = (-1,) + tuple([1] * (dim - 1))
 
-        if (string == 'b') or (string == 's'):
+        if (string == 'j') or (string == 'b') or (string == 's'):
             return self.eps_B[self.slices[string]].reshape(shape)
         else:
             return self.eps_A[self.slices[string]].reshape(shape)

--- a/Symmetry-Adapted-Perturbation-Theory/helper_SAPT.py
+++ b/Symmetry-Adapted-Perturbation-Theory/helper_SAPT.py
@@ -219,10 +219,13 @@ class helper_SAPT(object):
 
         shape = (-1,) + tuple([1] * (dim - 1))
 
-        if (string == 'j') or (string == 'b') or (string == 's'):
+        if (string == 'i') or (string == 'a') or (string == 'r'):
+            return self.eps_A[self.slices[string]].reshape(shape)
+        elif (string == 'j') or (string == 'b') or (string == 's'):
             return self.eps_B[self.slices[string]].reshape(shape)
         else:
-            return self.eps_A[self.slices[string]].reshape(shape)
+            psi4.core.clean()
+            raise Exception('Unknown orbital type in eps: %s.' % string)
 
     # Grab MO potential matrices
     def potential(self, string, side):

--- a/Tutorials/07_Symmetry_Adapted_Perturbation_Theory/helper_SAPT.py
+++ b/Tutorials/07_Symmetry_Adapted_Perturbation_Theory/helper_SAPT.py
@@ -219,7 +219,7 @@ class helper_SAPT(object):
 
         shape = (-1,) + tuple([1] * (dim - 1))
 
-        if (string == 'b') or (string == 's'):
+        if (string == 'j') or (string == 'b') or (string == 's'):
             return self.eps_B[self.slices[string]].reshape(shape)
         else:
             return self.eps_A[self.slices[string]].reshape(shape)

--- a/Tutorials/07_Symmetry_Adapted_Perturbation_Theory/helper_SAPT.py
+++ b/Tutorials/07_Symmetry_Adapted_Perturbation_Theory/helper_SAPT.py
@@ -219,10 +219,13 @@ class helper_SAPT(object):
 
         shape = (-1,) + tuple([1] * (dim - 1))
 
-        if (string == 'j') or (string == 'b') or (string == 's'):
+        if (string == 'i') or (string == 'a') or (string == 'r'):
+            return self.eps_A[self.slices[string]].reshape(shape)
+        elif (string == 'j') or (string == 'b') or (string == 's'):
             return self.eps_B[self.slices[string]].reshape(shape)
         else:
-            return self.eps_A[self.slices[string]].reshape(shape)
+            psi4.core.clean()
+            raise Exception('Unknown orbital type in eps: %s.' % string)
 
     # Grab MO potential matrices
     def potential(self, string, side):


### PR DESCRIPTION
A simple fix in the code for the SAPT orbital energies. The old code sometimes picked energies from the wrong monomer in the open-shell case.