### PR TITLE
CI: hopefully get int deriv tests running

### DIFF
--- a/tests/addons.py
+++ b/tests/addons.py
@@ -41,7 +41,7 @@ using_psi4_libxc = pytest.mark.skipif(is_psi4_new_enough("1.2a1.dev100") is Fals
 using_psi4_efpmints = pytest.mark.skipif(is_psi4_new_enough("1.2a1.dev507") is False,
                                 reason="Psi4 does not include EFP integrals in mints. Update to development head")
 
-using_psi4_python_integral_deriv = pytest.mark.skipif(is_psi4_new_enough("1000") is False,
+using_psi4_python_integral_deriv = pytest.mark.skipif(is_psi4_new_enough("1.2a1.dev1000") is False,
                                 reason="Psi4 does not include derivatives of integrals exported to python. Update to development head")
 
 using_numpy_113 = pytest.mark.skipif(is_numpy_new_enough("1.13.0") is False,


### PR DESCRIPTION
## Description
Psi is a ways off from v1000, but we do have integral derivatives in the current Psi CI is pulling. Let's try to get all impl testing.

## Status
- [x] Click when ready for review-and-merge
