### PR TITLE
Update 5b_density-fitted-mp2.ipynb

### DIFF
--- a/Tutorials/05_Moller-Plesset/5b_density-fitted-mp2.ipynb
+++ b/Tutorials/05_Moller-Plesset/5b_density-fitted-mp2.ipynb
@@ -98,7 +98,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From the conventional MP2 program, we know that the next step is to obtain the ERIs and transform them into the MO basis using the orbital coefficient matrix, **C**.  In order to do this using density-fitted integrals, must first build and transform the DF-ERI's similar to that in the density-fitted HF chapter."
+    "From the conventional MP2 program, we know that the next step is to obtain the ERIs and transform them into the MO basis using the orbital coefficient matrix, **C**.  In order to do this using density-fitted integrals, we must first build and transform the DF-ERI's similar to that in the density-fitted HF chapter. However, we use an auxiliary basis set that better reproduces the valence electrons important for correlation compared to the JKFIT auxiliary basis of Hartree-Fock. We instead use the RIFIT auxiliary basis."
    ]
   },
   {
@@ -110,8 +110,8 @@
    "outputs": [],
    "source": [
     "# ==> Density Fitted ERIs <==\n",
-    "# Build auxiliar basis set\n",
-    "aux = psi4.core.BasisSet.build(mol, \"DF_BASIS_SCF\", \"\", \"JKFIT\", \"aug-cc-pVDZ\")\n",
+    "# Build auxiliary basis set\n",
+    "aux = psi4.core.BasisSet.build(mol, \"DF_BASIS_SCF\", \"\", \"RIFIT\", \"aug-cc-pVDZ\")\n",
     "\n",
     "# Build instance of Mints object\n",
     "orb = scf_wfn.basisset()\n",
@@ -268,7 +268,7 @@
    "outputs": [],
    "source": [
     "# ==> Compare to Psi4 <==\n",
-    "psi4.compare_values(psi4.energy('mp2'), MP2_E, 6, 'MP2 Energy')"
+    "psi4.compare_values(psi4.energy('mp2'), MP2_E, 8, 'MP2 Energy')"
    ]
   },
   {


### PR DESCRIPTION
Use RIFIT instead of JKFIT integrals. This allows us to tighten our MP2 energy check to within our HF convergence tolerance. Also added a line briefly explaining the use of RIFIT as opposed to JKFIT integrals.

@dgasmith @dsirianni 

## Status
- [x] Click when ready for review-and-merge
