### PR TITLE
Update DF-MP2.py

### DIFF
--- a/Moller-Plesset/DF-MP2.py
+++ b/Moller-Plesset/DF-MP2.py
@@ -127,7 +127,7 @@ print('MP2 OS correlation energy:         %16.10f' % MP2corr_OS)
 print('\nMP2 correlation energy:            %16.10f' % MP2corr_E)
 print('MP2 total energy:                  %16.10f' % MP2_E)
 
-print('\nSCS-MP2 correlation energy:        %16.10f' % MP2corr_SS)
+print('\nSCS-MP2 correlation energy:        %16.10f' % SCS_MP2corr_E)
 print('SCS-MP2 total energy:              %16.10f' % SCS_MP2_E)
 
 if check_energy:


### PR DESCRIPTION
Fixed issue such that it prints SCS-MP2 correlation energy instead of same-spin MP2 correlation energy.