### PR TITLE
Update MP2.py

### DIFF
--- a/Moller-Plesset/MP2.py
+++ b/Moller-Plesset/MP2.py
@@ -101,7 +101,7 @@ print('MP2 OS correlation energy:         %16.10f' % MP2corr_OS)
 print('\nMP2 correlation energy:            %16.10f' % MP2corr_E)
 print('MP2 total energy:                  %16.10f' % MP2_E)
 
-print('\nSCS-MP2 correlation energy:        %16.10f' % MP2corr_SS)
+print('\nSCS-MP2 correlation energy:        %16.10f' % SCS_MP2corr_E)
 print('SCS-MP2 total energy:              %16.10f' % SCS_MP2_E)
 
 if check_energy:


### PR DESCRIPTION
The SCS-MP2 correlation energy was printing the SS-MP2 correlation energy.
A simple variable switch was performed in line 104:
print('\nSCS-MP2 correlation energy: %16.10f' % SCS_MP2corr_E)
instead of,
print('\nSCS-MP2 correlation energy: %16.10f' % MP2corr_SS)

## Description
Please provide a brief description of the PR's purpose here.

## What are your new additions? Please provide a brief list.
* **New Features**
  - [ ] Feature1
  - [ ] Feature2

* **Changes**
  - [x] Change1  

## Any questions for the community?
- [ ] Question1

## Status
- [ ] Click when ready for review-and-merge
