### PR TITLE
Fix frequency-dependent iterative CPHF

### DIFF
--- a/Response-Theory/Self-Consistent-Field/CPHF.py
+++ b/Response-Theory/Self-Consistent-Field/CPHF.py
@@ -42,8 +42,8 @@ symmetry c1
 psi4.set_options({"basis": "aug-cc-pVDZ",
                   "scf_type": "direct",
                   "df_scf_guess": False,
-                  "e_convergence": 1e-9,
-                  "d_convergence": 1e-9,
+                  "e_convergence": 1e-11,
+                  "d_convergence": 1e-11,
                   "cphf_tasks": ['polarizability']})
 
 # Set defaults

--- a/Response-Theory/Self-Consistent-Field/helper_CPHF.py
+++ b/Response-Theory/Self-Consistent-Field/helper_CPHF.py
@@ -84,6 +84,8 @@ class helper_CPHF(object):
         self.form_polarizability()
 
     def solve_static_direct(self):
+        self.x = None
+        self.rhsvecs = None
         # Run a quick check to make sure everything will fit into memory
         I_Size = (self.nbf ** 4) * 8.e-9
         oNNN_Size = (self.nocc * self.nbf ** 3) * 8.e-9
@@ -137,6 +139,8 @@ class helper_CPHF(object):
             self.rhsvecs.append(rhsvec)
 
     def solve_dynamic_direct(self, omega=0.0):
+        self.x = None
+        self.rhsvecs = None
         # Adapted completely from TDHF.py
 
         eps_v = self.epsilon[self.nocc:]
@@ -197,6 +201,8 @@ class helper_CPHF(object):
             self.x.append(xcomp)
 
     def solve_static_iterative(self, maxiter=20, conv=1.e-9, use_diis=True):
+        self.x = None
+        self.rhsvecs = None
 
         # Init JK object
         jk = psi4.core.JK.build(self.scf_wfn.basisset())
@@ -274,6 +280,8 @@ class helper_CPHF(object):
                   (CPHF_ITER, avg_RMS, max_RMS))
 
     def solve_dynamic_iterative(self, omega=0.0, maxiter=20, conv=1.e-9, use_diis=True):
+        self.x = None
+        self.rhsvecs = None
 
         # Init JK object
         jk = psi4.core.JK.build(self.scf_wfn.basisset())

--- a/Response-Theory/Self-Consistent-Field/helper_CPHF.py
+++ b/Response-Theory/Self-Consistent-Field/helper_CPHF.py
@@ -370,24 +370,26 @@ class helper_CPHF(object):
                 print('CPHF converged in %d iterations and %.2f seconds.' % (CPHF_ITER, time.time() - t))
                 self.rhsvecs = []
                 self.x = []
-                # do one last perturbed density build in the AO basis
-                for i, rhsmat in enumerate(rhsmats):
-                    l = C[:, :self.nocc] @ C.dot(x[i].T)[:, :self.nocc].T - C.dot(x[i])[:, :self.nocc] @ C[:, :self.nocc].T
-                    r = self.tmp_dipoles[i].np
-                    self.rhsvecs.append(-2 * l.reshape(-1))
-                    self.x.append(r.reshape(-1))
-                # res = l.reshape(-1).dot(r.reshape(-1)) * -2
-                #     self.rhsvecs = []
-                #     self.x = []
-                #     for numx in range(3):
-                #         rhsvec = self.dipoles_xyz[numx].reshape(-1)
-                #         self.rhsvecs.append(np.concatenate((rhsvec, -rhsvec)))
-                #         self.x.append(np.concatenate((x_l[numx].reshape(-1),
-                #                                       x_r[numx].reshape(-1))))
+                for numx in range(3):
+                    self.rhsvecs.append(
+                        np.concatenate(
+                            (
+                                self.dipoles_xyz[numx].reshape(-1),
+                                -self.dipoles_xyz[numx].T.reshape(-1),
+                            )
+                        )
+                    )
+                    self.x.append(
+                        np.concatenate(
+                            (
+                                x[numx][: self.nocc, self.nocc :].reshape(-1),
+                                x[numx][self.nocc :, : self.nocc].reshape(-1),
+                            )
+                        )
+                    )
                 break
 
-            print('CPHF Iteration %3d: Average RMS = %3.8f  Maximum RMS = %3.8f' %
-                  (CPHF_ITER, avg_RMS, max_RMS))
+            print('CPHF Iteration %3d: Average RMS = %3.8f  Maximum RMS = %3.8f' % (CPHF_ITER, avg_RMS, max_RMS))
 
     def form_polarizability(self):
         self.polar = np.empty((3, 3))

--- a/Response-Theory/Self-Consistent-Field/helper_CPHF.py
+++ b/Response-Theory/Self-Consistent-Field/helper_CPHF.py
@@ -338,11 +338,9 @@ class helper_CPHF(object):
 
                 # Bulid new guess
                 U = x[xyz].copy()
-                AU = x[xyz] * all_denom - (C.T).dot(2 * J_l - K_l + 2 * J_r - K_r).dot(C)
-                for i in range(self.nocc):
-                    for a in range(self.nocc, norb):
-                        U[i, a] += (rhsmats[xyz][i, a] - AU[i, a]) / (self.epsilon[i] - self.epsilon[a] - omega)
-                        U[a, i] += (rhsmats[xyz][a, i] - AU[a, i]) / (self.epsilon[a] - self.epsilon[i] - omega)
+                upd = (rhsmats[xyz] - (x[xyz] * all_denom - (C.T).dot(2 * J_l - K_l + 2 * J_r - K_r).dot(C))) / all_denom
+                U[:self.nocc, self.nocc:] += upd[:self.nocc, self.nocc:]
+                U[self.nocc:, :self.nocc] += upd[self.nocc:, :self.nocc]
                 # DIIS for good measure
                 if use_diis:
                     diis[xyz].add(U, U - x_old[xyz])

--- a/Response-Theory/Self-Consistent-Field/helper_CPHF.py
+++ b/Response-Theory/Self-Consistent-Field/helper_CPHF.py
@@ -64,9 +64,6 @@ class helper_CPHF(object):
             Fia *= -2
             self.dipoles_xyz.append(Fia)
 
-        self.x = None
-        self.rhsvecs = None
-
     def run(self, method='direct', omega=None):
         self.method = method
         if self.method == 'direct':
@@ -84,8 +81,6 @@ class helper_CPHF(object):
         self.form_polarizability()
 
     def solve_static_direct(self):
-        self.x = None
-        self.rhsvecs = None
         # Run a quick check to make sure everything will fit into memory
         I_Size = (self.nbf ** 4) * 8.e-9
         oNNN_Size = (self.nocc * self.nbf ** 3) * 8.e-9
@@ -139,8 +134,6 @@ class helper_CPHF(object):
             self.rhsvecs.append(rhsvec)
 
     def solve_dynamic_direct(self, omega=0.0):
-        self.x = None
-        self.rhsvecs = None
         # Adapted completely from TDHF.py
 
         eps_v = self.epsilon[self.nocc:]
@@ -201,8 +194,6 @@ class helper_CPHF(object):
             self.x.append(xcomp)
 
     def solve_static_iterative(self, maxiter=20, conv=1.e-9, use_diis=True):
-        self.x = None
-        self.rhsvecs = None
 
         # Init JK object
         jk = psi4.core.JK.build(self.scf_wfn.basisset())
@@ -280,8 +271,6 @@ class helper_CPHF(object):
                   (CPHF_ITER, avg_RMS, max_RMS))
 
     def solve_dynamic_iterative(self, omega=0.0, maxiter=20, conv=1.e-10, use_diis=True):
-        self.x = None
-        self.rhsvecs = None
 
         # Init JK object
         jk = psi4.core.JK.build(self.scf_wfn.basisset())

--- a/Response-Theory/Self-Consistent-Field/helper_CPHF.py
+++ b/Response-Theory/Self-Consistent-Field/helper_CPHF.py
@@ -283,6 +283,10 @@ class helper_CPHF(object):
         self.x = None
         self.rhsvecs = None
 
+        # Init JK object
+        jk = psi4.core.JK.build(self.scf_wfn.basisset())
+        jk.initialize()
+
         # Build initial guess, previous vectors, and DIIS objects
         norb = self.scf_wfn.nmo()
         C = np.asarray(self.C)
@@ -299,10 +303,6 @@ class helper_CPHF(object):
             x.append(U)
             x_old.append(np.zeros_like(U))
             diis.append(DIIS_helper())
-
-        # Init JK object
-        jk = psi4.core.JK.build(self.scf_wfn.basisset())
-        jk.initialize()
 
         # Add blank matrices to the jk object and NumPy hooks to C_right,
         # which will contain MO coefficients contracted with the response

--- a/Response-Theory/Self-Consistent-Field/helper_CPHF.py
+++ b/Response-Theory/Self-Consistent-Field/helper_CPHF.py
@@ -321,7 +321,7 @@ class helper_CPHF(object):
         t = time.time()
         for CPHF_ITER in range(1, maxiter + 1):
 
-            for xyz in range(3):
+            for xyz in range(len(rhsmats)):
                 npCx_l[xyz][:] = C.dot(x[xyz].T)[:, :self.nocc]
                 npCx_r[xyz][:] = (-C).dot(x[xyz])[:, :self.nocc]
 
@@ -329,12 +329,12 @@ class helper_CPHF(object):
             jk.compute()
 
             # Update amplitudes
-            for xyz in range(3):
+            for xyz in range(len(rhsmats)):
                 # Build J and K objects
                 J_l = np.asarray(jk.J()[xyz])
                 K_l = np.asarray(jk.K()[xyz])
-                J_r = np.asarray(jk.J()[xyz + 3])
-                K_r = np.asarray(jk.K()[xyz + 3])
+                J_r = np.asarray(jk.J()[xyz + len(rhsmats)])
+                K_r = np.asarray(jk.K()[xyz + len(rhsmats)])
 
                 # Bulid new guess
                 U = x[xyz].copy()


### PR DESCRIPTION
A bug where the list holding response vectors (`self.x`) wasn't cleared was hiding the fact that `solve_dynamic_iterative` was not correct.