### PR TITLE
Adds LT-MP2 reference implementation

### DIFF
--- a/Moller-Plesset/LT-MP2.py
+++ b/Moller-Plesset/LT-MP2.py
@@ -1,0 +1,100 @@
+"""
+A reference implementation of MP2 using the Laplace transformation for a restricted reference.
+This is performed in an MO basis for demonstration, but LT-MP2 can be extended to AO-LT-MP2.
+
+References:
+    M. Haser, J. Almlof, and G. E. Scuseria, Chem. Phys. Lett. 181, 497 (1991).
+    P. Y. Ayala and G. E. Scuseria, J. Chem. Phys., 110, 3660 (1999).
+"""
+
+__authors__ = "Oliver J. Backhouse"
+__credits__ = ["Oliver J. Backhouse"]
+
+__copyright__ = "(c) 2014-2020, The Psi4NumPy Developers"
+__license__ = "BSD-3-Clause"
+__date__ = "2018-03-01"
+
+import time
+import numpy as np
+import psi4
+
+# Settings
+compare_to_psi4 = True
+grid_size = 40
+
+# Set the memory and output file
+psi4.set_memory('2 GB')
+psi4.core.set_output_file('output.dat', False)
+
+# Set molecule and basis
+mol = psi4.geometry("""
+O
+H 1 1.1
+H 1 1.1 2 104
+symmetry c1
+""")
+
+psi4.set_options({'basis': 'aug-cc-pvdz'})
+
+# Perform SCF
+print('\nPerforming SCF...')
+e_scf, wfn = psi4.energy('SCF', return_wfn=True)
+mints = psi4.core.MintsHelper(wfn.basisset())
+
+# Get occupied and virtual MO energies and coefficients
+e_occ = wfn.epsilon_a_subset('AO', 'ACTIVE_OCC').np 
+e_vir = wfn.epsilon_a_subset('AO', 'ACTIVE_VIR').np
+c_occ = wfn.Ca_subset('AO', 'OCC')
+c_vir = wfn.Ca_subset('AO', 'VIR')
+
+# Get the two-electron integrals in MO basis
+print('Building MO integrals...')
+iajb = mints.mo_eri(c_occ, c_vir, c_occ, c_vir).np
+
+# Build the grids and weights according to Gauss-Laguerre quadrature
+# Also apply a weighting function w(x) = exp(x)
+grid, weights = np.polynomial.laguerre.laggauss(grid_size)
+weights *= np.exp(grid)
+
+# Loop over grid points and compute energies
+e_mp2_corr_os = 0.0
+e_mp2_corr_ss = 0.0
+
+print('Looping over %d grid points...' % grid_size)
+t_start = time.time()
+for t, w in zip(grid, weights):
+    # Transform the two-electron integrals into the time-dependent form
+    t_occ = np.exp( t * 0.5 * e_occ)
+    t_vir = np.exp(-t * 0.5 * e_vir)
+    iajb_t = np.einsum('p,q,r,s,pqrs->pqrs', t_occ, t_vir, t_occ, t_vir, iajb)
+
+    # Calculate MP2 energy for spin cases
+    e_mp2_corr_os_contr = np.einsum('ijkl,ijkl->', iajb_t, iajb_t)
+    e_mp2_corr_ss_contr = np.einsum('ijkl,ijkl->', iajb_t, iajb_t - iajb_t.swapaxes(1, 3))
+
+    # Add to total including weights
+    e_mp2_corr_os -= w * e_mp2_corr_os_contr
+    e_mp2_corr_ss -= w * e_mp2_corr_ss_contr
+
+e_mp2_corr = e_mp2_corr_os + e_mp2_corr_ss
+e_mp2 = e_scf + e_mp2_corr
+
+e_scs_mp2_corr = e_mp2_corr_os * (6. / 5) + e_mp2_corr_ss / 3
+e_scs_mp2 = e_scf + e_scs_mp2_corr
+
+print('MP2 energy calculated in %.3f seconds.\n' % (time.time() - t_start))
+
+print('\nMP2 SS correlation energy:  %16.10f' % e_mp2_corr_ss)
+print('MP2 OS correlation energy:  %16.10f' % e_mp2_corr_os)
+                                   
+print('\nMP2  correlation energy:    %16.10f' % e_mp2_corr)
+print('MP2 total energy:           %16.10f' % e_mp2)
+
+print('\nSCS-MP2 correlation energy: %16.10f' % e_scs_mp2_corr)
+print('SCS-MP2 total energy:       %16.10f\n' % e_scs_mp2)
+
+if compare_to_psi4:
+    psi4.energy('MP2')
+    psi4.compare_values(psi4.core.variable('MP2 TOTAL ENERGY'), e_mp2, 4, 'MP2 Energy')
+    psi4.compare_values(psi4.core.variable('SCS-MP2 TOTAL ENERGY'), e_scs_mp2, 4, 'SCS-MP2 Energy')
+

--- a/Moller-Plesset/README.md
+++ b/Moller-Plesset/README.md
@@ -16,6 +16,7 @@ ontop of this result.
  - `MPn.py`: An example on how to automate the contraction of higher order MP theory.
  - `MP2_Gradient.py`: Calculation of a nuclear gradient at the MP2 level of theory.
  - `MP2_Hessian.py`: Calculation of a nuclear hessian at the MP2 level of theory.
+ - `LT-MP2.py`: Laplaced-transformed MP2 for a restricted reference.
 
 ### References
  1) The original paper that started it all: "Note on an Approximation Treatment for Many-Electron Systems"
@@ -26,3 +27,5 @@ ontop of this result.
     - [[Szabo:1996](https://books.google.com/books?id=KQ3DAgAAQBAJ&printsec=frontcover&dq=szabo+%26+ostlund&hl=en&sa=X&ved=0ahUKEwiYhv6A8YjUAhXLSCYKHdH5AJ4Q6AEIJjAA#v=onepage&q=szabo%20%26%20ostlund&f=false)] A. Szabo and N. S. Ostlund, *Modern Quantum Chemistry: Introduction to Advanced Electronic Structure Theory.* Courier Corporation, 1996.
  4) sDF-MP2 reference:
     - [[Takeshita:2017:4605](https://pubs.acs.org/doi/abs/10.1021/acs.jctc.7b00343)] T.Y. Takeshita, W.A. de Jong, D. Neuhauser, R. Baer and E. Rabani, *J. chem. Theory Comput.* **13**, 4605 (2017)
+ 5) Laplaced-transformed MP2 reference:
+    - [[Almlof:1991](https://doi.org/10.1016/0009-2614(91)80078-C)] J. Almlöf, *Chem. Phys. Lett.* **181**, 319 (1991)


### PR DESCRIPTION
## Description
Adds LT-MP2 in a restricted reference. I dug out some code and reformatted it using the contributing guide, as there are references to Laplace transformed MP2 in some of the MP2 tutorials but no reference implementation for it, hope it is of help.

## What are your new additions? Please provide a brief list.
* **New Features**
  - [ ] Laplace transformed MP2 (LT-MP2) with restricted reference.

* **Changes**
  - [ ] Adds LT-MP2.py 
