### PR TITLE
Update 5b_density-fitted-mp2.ipynb

### DIFF
--- a/Tutorials/05_Moller-Plesset/5b_density-fitted-mp2.ipynb
+++ b/Tutorials/05_Moller-Plesset/5b_density-fitted-mp2.ipynb
@@ -132,7 +132,7 @@
     "# Transform Qpq -> Qmo @ O(N^5)\n",
     "Qmo = np.einsum('pi,Qpq,qj->Qij', C, Qpq, C)\n",
     "~~~\n",
-    "This simple transformation works, but it doesn't reduce the caling of the transformation.  This approach saves over the conventional one only because a single ${\\cal O}(N^5)$ transformation would need to be done, instead of four.  We can, however, borrow the idea from conventional MP2 to carry out the transformation in more than one step, saving the intermediates along the way.  Using this approach, we are able to transform the `Qpq` tensors into the MO basis in two successive ${\\cal O}(N^4)$ steps. Passing the `optimize=True` flag will do this for you. To see how it's done manually, in the cell below, we transform the `Qpq` tensors with this reduced scaling algorithm, and save the occupied-virtual slice of the full `Qmo` tensor:"
+    "This simple transformation works, but it doesn't reduce the scaling of the transformation.  This approach saves over the conventional one only because a single ${\\cal O}(N^5)$ transformation would need to be done, instead of four.  We can, however, borrow the idea from conventional MP2 to carry out the transformation in more than one step, saving the intermediates along the way.  Using this approach, we are able to transform the `Qpq` tensors into the MO basis in two successive ${\\cal O}(N^4)$ steps. Passing the `optimize=True` flag will do this for you. To see how it's done manually, in the cell below, we transform the `Qpq` tensors with this reduced scaling algorithm, and save the occupied-virtual slice of the full `Qmo` tensor:"
    ]
   },
   {

--- a/Tutorials/05_Moller-Plesset/5b_density-fitted-mp2.ipynb
+++ b/Tutorials/05_Moller-Plesset/5b_density-fitted-mp2.ipynb
@@ -130,9 +130,9 @@
     "Now that we have our three-index integrals, we are able to transform them into the MO basis.  To do this, we could simply use `np.einsum()` to carry out the transformation in a single step:\n",
     "~~~python\n",
     "# Transform Qpq -> Qmo @ O(N^5)\n",
-    "Qmo = np.einsum('pi,Qpq,qj->Qij', C, Qpq, C, optimize=True)\n",
+    "Qmo = np.einsum('pi,Qpq,qj->Qij', C, Qpq, C)\n",
     "~~~\n",
-    "This simple transformation works, but it doesn't reduce the caling of the transformation.  This approach saves over the conventional one only because a single ${\\cal O}(N^5)$ transformation would need to be done, instead of four.  We can, however, borrow the idea from conventional MP2 to carry out the transformation in more than one step, saving the intermediates along the way.  Using this approach, we are able to transform the `Qpq` tensors into the MO basis in two successive ${\\cal O}(N^4)$ steps.  In the cell below, transform the `Qpq` tensors with this reduced scaling algorithm, and save the occupied-virtual slice of the full `Qmo` tensor:"
+    "This simple transformation works, but it doesn't reduce the caling of the transformation.  This approach saves over the conventional one only because a single ${\\cal O}(N^5)$ transformation would need to be done, instead of four.  We can, however, borrow the idea from conventional MP2 to carry out the transformation in more than one step, saving the intermediates along the way.  Using this approach, we are able to transform the `Qpq` tensors into the MO basis in two successive ${\\cal O}(N^4)$ steps. Passing the `optimize=True` flag will do this for you. To see how it's done manually, in the cell below, we transform the `Qpq` tensors with this reduced scaling algorithm, and save the occupied-virtual slice of the full `Qmo` tensor:"
    ]
   },
   {


### PR DESCRIPTION
A previous commit was overzealous with passing in `optimize=True` and included it in one line where it was deliberately _not_ being used for pedagogical purposes. This commit removes it and makes this point explicit in the surrounding text.

## Status
- [x] Click when ready for review-and-merge
