### PR TITLE
Fix bug in Velocity Verlet

### DIFF
--- a/MD-Verlet-Integrator/md_helper.py
+++ b/MD-Verlet-Integrator/md_helper.py
@@ -71,7 +71,7 @@ def integrator(int_alg,timestep,pos,veloc,accel,molec,grad_method):
         molec.set_geometry(psi4.core.Matrix.from_array(pos_new))
         E,force_new = get_forces(grad_method)
         accel_new = force_new/(atom_mass.reshape((natoms,1)))
-        vel_new += 0*5*timestep*accel_new
+        vel_new += 0.5*timestep*accel_new
     return pos_new,vel_new,accel_new,E
 
 def get_forces(grad_method):

--- a/MD-Verlet-Integrator/md_prog.py
+++ b/MD-Verlet-Integrator/md_prog.py
@@ -77,4 +77,4 @@ for i in range(1,max_md_step+1):
 md_energy.close()
 if trajec:
     md_helper.md_trajectories(max_md_step)
-print "Done with Molecular Dynamics Program!"
+print("Done with Molecular Dynamics Program!")


### PR DESCRIPTION
## Description
@pwborthwick recently pointed out that the Velocity Verlet code had "0*5" instead of "0.5", which led to incorrect behavior. The print statement also was not consistent with Python3.

## What are your new additions? Please provide a brief list.

* **Changes**
  - [ ] Fix typo in Velocity Verlet code
  - [ ] Change `print` statements to be python3 consistent 

## Status
- [ ] Click when ready for review-and-merge
