### PR TITLE
bug in Slater-Condon rules (Configuration Interaction)

### DIFF
--- a/Configuration-Interaction/helper_CI.py
+++ b/Configuration-Interaction/helper_CI.py
@@ -446,12 +446,15 @@ class HamiltonianGenerator:
         numUniqueOrbitals = None
         if det1.diff2OrLessOrbitals(det2):
             numUniqueOrbitals = det1.numberOfTotalDiffOrbitals(det2)
+            if numUniqueOrbitals == 0:
+                return self.calcMatrixElementIdentialDet(det1)
             if numUniqueOrbitals == 2:
                 return self.calcMatrixElementDiffIn2(det1, det2)
             elif numUniqueOrbitals == 1:
                 return self.calcMatrixElementDiffIn1(det1, det2)
             else:
-                return self.calcMatrixElementIdentialDet(det1)
+                # 
+                return 0.0
         else:
             return 0.0
 


### PR DESCRIPTION
## Description
The implementation of the Slater-Condon rules in `helper_CI.py` has a bug. Determinants that differ by 3 or 4 spin orbitals are treated as identical. The example with H2O works by accident, but in general the final energy does not agree with the psi4 implementation. The script below is for LiF and will fail to reproduce the correct CISD energy. This pull request fixes the bug, so that the energies agree.

```python
import time
import numpy as np
np.set_printoptions(precision=5, linewidth=200, suppress=True)
import psi4

# Check energy against psi4?
compare_psi4 = True

# Memory for Psi4 in GB
# psi4.core.set_memory(int(2e9), False)
psi4.core.set_output_file('output.dat', False)

# Memory for numpy in GB
numpy_memory = 2

mol = psi4.geometry("""
Li
F  1  1.6
symmetry c1
""")

psi4.set_options({'basis': 'sto-3g', 'scf_type': 'pk', 'e_convergence': 1e-8, 'd_convergence': 1e-8})

print('\nStarting SCF and integral build...')
t = time.time()

# First compute SCF energy using Psi4
scf_e, wfn = psi4.energy('SCF', return_wfn=True)

# Grab data from wavfunction class
C = wfn.Ca()
ndocc = wfn.doccpi()[0]
nmo = wfn.nmo()
nvirt = nmo - ndocc

# Compute size of Hamiltonian in GB
from scipy.special import comb
nDet_S = ndocc * nvirt * 2
nDet_D = 2 * comb(ndocc, 2) * comb(nvirt, 2) + ndocc**2 * nvirt**2
nDet = 1 + nDet_S + nDet_D
H_Size = nDet**2 * 8e-9
print('\nSize of the Hamiltonian Matrix will be %4.2f GB.' % H_Size)
if H_Size > numpy_memory:
    clean()
    raise Exception("Estimated memory utilization (%4.2f GB) exceeds numpy_memory \
                    limit of %4.2f GB." % (H_Size, numpy_memory))

# Integral generation from Psi4's MintsHelper
t = time.time()
mints = psi4.core.MintsHelper(wfn.basisset())
H = np.asarray(mints.ao_kinetic()) + np.asarray(mints.ao_potential())

print('\nTotal time taken for ERI integrals: %.3f seconds.\n' % (time.time() - t))

#Make spin-orbital MO
print('Starting AO -> spin-orbital MO transformation...')
t = time.time()
MO = np.asarray(mints.mo_spin_eri(C, C))

# Update H, transform to MO basis and tile for alpha/beta spin
H = np.einsum('uj,vi,uv', C, C, H)
H = np.repeat(H, 2, axis=0)
H = np.repeat(H, 2, axis=1)

# Make H block diagonal
spin_ind = np.arange(H.shape[0], dtype=np.int) % 2
H *= (spin_ind.reshape(-1, 1) == spin_ind)

print('..finished transformation in %.3f seconds.\n' % (time.time() - t))

from helper_CI import Determinant, HamiltonianGenerator
from itertools import combinations

print('Generating %d CISD Determinants...' % (nDet))
t = time.time()

occList = [i for i in range(ndocc)]
det_ref = Determinant(alphaObtList=occList, betaObtList=occList)
detList = det_ref.generateSingleAndDoubleExcitationsOfDet(nmo)
detList.append(det_ref)

print('..finished generating determinants in %.3f seconds.\n' % (time.time() - t))

print('Generating Hamiltonian Matrix...')

t = time.time()
Hamiltonian_generator = HamiltonianGenerator(H, MO)
Hamiltonian_matrix = Hamiltonian_generator.generateMatrix(detList)

print('..finished generating Matrix in %.3f seconds.\n' % (time.time() - t))

print('Diagonalizing Hamiltonian Matrix...')

t = time.time()

e_cisd, wavefunctions = np.linalg.eigh(Hamiltonian_matrix)
print('..finished diagonalization in %.3f seconds.\n' % (time.time() - t))

cisd_mol_e = e_cisd[0] + mol.nuclear_repulsion_energy()

print('# Determinants:      % 16d' % (len(detList)))

print('SCF energy:          % 16.10f' % (scf_e))
print('CISD correlation:    % 16.10f' % (cisd_mol_e - scf_e))
print('Total CISD energy:   % 16.10f' % (cisd_mol_e))

if compare_psi4:
    psi4.compare_values(psi4.energy('DETCI'), cisd_mol_e, 6, 'CISD Energy')

```
