### PR TITLE
Addresses #119 and prints quasiparticle weight

### DIFF
--- a/Algebraic-Diagrammatic-Construction/IP_EA_ADC2.py
+++ b/Algebraic-Diagrammatic-Construction/IP_EA_ADC2.py
@@ -148,9 +148,11 @@ guess = np.eye(diag.size)[:, arg[:n_states]]
 e_ip, v_ip = davidson(ip_matvec, guess, diag, tol=tol)
 
 # Print the IPs - each should be doubly degenerate
-print('\n%2s %16s %16s' % ('#', 'IP (Ha)', 'IP (eV)'))
+# Also printed is the quasiparticle weight (weight in the singles space)
+print('\n%2s %16s %16s %16s' % ('#', 'IP (Ha)', 'IP (eV)', 'QP weight'))
 for i in range(n_states):
-    print('%2d %16.8f %16.8f' % (i, -e_ip[i], -e_ip[i] * 27.21139664))
+    qpwt = np.linalg.norm(v_ip[:nocc, i])**2
+    print('%2d %16.8f %16.8f %16.8f' % (i, -e_ip[i], -e_ip[i] * 27.21139664, qpwt))
 print()
 
 # Compute the diagonal of the EA-ADC(2) matrix to use as a preconditioner
@@ -163,6 +165,8 @@ guess = np.eye(diag.size)[:, arg[:n_states]]
 e_ea, v_ea = davidson(ea_matvec, guess, diag, tol=tol)
 
 # Print the states - each should be doubly degenerate
-print('\n%2s %16s %16s' % ('#', 'EA (Ha)', 'EA (eV)'))
+# Also printed is the quasiparticle weight (weight in the singles space)
+print('\n%2s %16s %16s %16s' % ('#', 'EA (Ha)', 'EA (eV)', 'QP weight'))
 for i in range(n_states):
-    print('%2d %16.8f %16.8f' % (i, e_ea[i], e_ea[i] * 27.21139664))
+    qpwt = np.linalg.norm(v_ea[:nvir, i])**2
+    print('%2d %16.8f %16.8f %16.8f' % (i, e_ea[i], e_ea[i] * 27.21139664, qpwt))

--- a/Algebraic-Diagrammatic-Construction/adc_helper.py
+++ b/Algebraic-Diagrammatic-Construction/adc_helper.py
@@ -65,4 +65,6 @@ def davidson(matrix, guesses, diag, maxiter=None, sort_via_abs=True, tol=1e-10, 
             else:
                 b = np.concatenate([b, np.column_stack(b_new)], axis=1)
 
+    b = b[:, :guesses.shape[-1]]
+
     return theta, b


### PR DESCRIPTION
## Description
This PR addresses bug #119 related to the return value corresponding to the eigenvectors in the Davidson code. I have also added printing of the quasiparticle weight for the IP and EA as some sort of demonstration of the physicality of the returned eigenvectors.

## What are your new additions? Please provide a brief list.
* **New Features**
  - [x] Prints quasiparticle weight for IP and EA-ADC(2)

* **Changes**
  - [x] Fixes returned eigenvector space in `adc_helper.davidson`

## Status
- [x] Click when ready for review-and-merge
