### PR TITLE
Correction to QED-CIS

### DIFF
--- a/Polaritonic-Quantum-Chemistry/CS_CQED_CIS.py
+++ b/Polaritonic-Quantum-Chemistry/CS_CQED_CIS.py
@@ -142,4 +142,5 @@ psi4.compare_values(cqed_cis_e_1[1], psi4_excitation_e[0], 8, "CASE 1 CQED-CIS E
 
 
 # check to see if first CQED-CIS excitation energy matches value from [McTague:2021:ChemRxiv] Figure 3 for case 2
-psi4.compare_values(cqed_cis_e_2[1], 0.16563136, 8, "CASE 2 CQED-CIS E")
+# This still needs to be corrected in the paper!
+psi4.compare_values(cqed_cis_e_2[1], 0.1655708380, 8, "CASE 2 CQED-CIS E")

--- a/Polaritonic-Quantum-Chemistry/helper_CS_CQED_CIS.py
+++ b/Polaritonic-Quantum-Chemistry/helper_CS_CQED_CIS.py
@@ -251,37 +251,7 @@ def cs_cqed_cis(lambda_vector, omega_val, molecule_string, psi4_options_dict):
                                 * (s == t - 1)
                                 * (i == j)
                             )
-                            # now handle diagonal in electronic term
-                            if a == b and i == j and s == t + 1:
-                                # l dot <mu> term
-                                Hep[ias, jbt] += (
-                                    np.sqrt(t + 1)
-                                    * np.sqrt(omega_val / 2)
-                                    * l_dot_mu_exp
-                                )
-                                # l dot mu terms
-                                for k in range(0, ndocc):
-                                    # sum over occupied indices
-                                    Hep[ias, jbt] -= (
-                                        np.sqrt(t + 1)
-                                        * np.sqrt(omega_val / 2)
-                                        * l_dot_mu_el[k, k]
-                                    )
 
-                            # now handle diagonal in electronic term
-                            if a == b and i == j and s == t - 1:
-                                # l dot <mu> term
-                                Hep[ias, jbt] += (
-                                    np.sqrt(t) * np.sqrt(omega_val / 2) * l_dot_mu_exp
-                                )
-                                # l dot mu terms
-                                for k in range(0, ndocc):
-                                    # sum over occupied indices
-                                    Hep[ias, jbt] -= (
-                                        np.sqrt(t)
-                                        * np.sqrt(omega_val / 2)
-                                        * l_dot_mu_el[k, k]
-                                    )
     # Form Htot from sum of all terms
     Htot = Hp + Hep + H1e + H2e + H2edp
     # now diagonalize H

--- a/Polaritonic-Quantum-Chemistry/helper_CS_CQED_CIS.py
+++ b/Polaritonic-Quantum-Chemistry/helper_CS_CQED_CIS.py
@@ -222,7 +222,7 @@ def cs_cqed_cis(lambda_vector, omega_val, molecule_string, psi4_options_dict):
                             Hp[ias, jbt] += (
                                 (omega_val * t) * (s == t) * (i == j) * (a == b)
                             )
-                            # bilinear coupling - off-diagonals first
+                            # bilinear coupling
                             Hep[ias, jbt] += (
                                 np.sqrt(t + 1)
                                 * np.sqrt(omega_val / 2)


### PR DESCRIPTION
## Description
The additional diagonal contributions to the bilinear coupling in QED-CIS should cancel. This is also wrong in the publication, which has already been discussed with the author and will hopefully be taken care of soon.

## What are your new additions? Please provide a brief list.
* **New Features**
  - [ ] QED-CIS is correct now

* **Changes**
  - [ ] Deleted terms, which should cancel anyway, but leave a nuclear dipole contribution in the previous implementation.
  - [ ] Corrected corresponding test 

## Status
- [x] Click when ready for review-and-merge
