### PR TITLE
Fix typo: swapped row and column in the description of the orbital co…

### DIFF
--- a/Tutorials/03_Hartree-Fock/3a_restricted-hartree-fock.ipynb
+++ b/Tutorials/03_Hartree-Fock/3a_restricted-hartree-fock.ipynb
@@ -44,7 +44,7 @@
     "\n",
     "$$D_{\\lambda\\sigma} = C_{\\sigma i}C_{\\lambda i}$$\n",
     "\n",
-    "Formally, the orbital coefficient matrix **C** is a $N\\times M$ matrix, where $N$ is the number of atomic basis functions, and $M$ is the total number of molecular orbitals.  Physically, this matrix describes the contribution of every atomic basis function (columns) to a particular molecular orbital (e.g., the $i^{\\rm th}$ row).  The density matrix **D** is a square matrix describing the electron density contained in each orbital.  In the molecular orbital basis, the density matrix has elements\n",
+    "Formally, the orbital coefficient matrix **C** is a $N\\times M$ matrix, where $N$ is the number of atomic basis functions, and $M$ is the total number of molecular orbitals.  Physically, this matrix describes the contribution of every atomic basis function (rows) to a particular molecular orbital (e.g., the $i^{\\rm th}$ column).  The density matrix **D** is a square matrix describing the electron density contained in each orbital.  In the molecular orbital basis, the density matrix has elements\n",
     "\n",
     "$$D_{pq} = \\left\\{\n",
     "\\begin{array}{ll}\n",


### PR DESCRIPTION
Corrected a minor typo in the text where the dimensions (rows and columns) of the orbital coefficient matrix C were swapped. 

## Description
In the LCAO-MO framework, rows correspond to atomic basis functions, and columns correspond to molecular orbitals. The original text had these reversed.

## What are your new additions? Please provide a brief list.

* **Changes**
  - [x] Documentation / Typo fix

## Any questions for the community?
None.

## Status
- [x] Click when ready for review-and-merge